### PR TITLE
remove wrist from controller yaml

### DIFF
--- a/sr_robot_launch/config/rh_trajectory_controller.yaml
+++ b/sr_robot_launch/config/rh_trajectory_controller.yaml
@@ -23,8 +23,6 @@ rh_trajectory_controller:
     - rh_THJ3
     - rh_THJ4
     - rh_THJ5
-    - rh_WRJ1
-    - rh_WRJ2
   constraints:
       goal_time: 0.6
       stopped_velocity_tolerance: 0.05
@@ -50,7 +48,5 @@ rh_trajectory_controller:
       rh_THJ3: {trajectory: 0.9, goal: 0.4}
       rh_THJ4: {trajectory: 0.9, goal: 0.4}
       rh_THJ5: {trajectory: 0.9, goal: 0.4}
-      rh_WRJ1: {trajectory: 0.9, goal: 0.4}
-      rh_WRJ2: {trajectory: 0.9, goal: 0.4}
   stop_trajectory_duration: 0.5
   allow_partial_joints_goal: true


### PR DESCRIPTION
removing wrist joints from hand controller yaml. This file is only used in right_srhand_ur10arm.launch. @VahidAminZ created a new trajectory_controller_spawner.py which searches for joints present so no need to duplicate this file (rh_trajectory_controller.yaml) for hand use only (without arm)
