### PR TITLE
F#104 change name current pose

### DIFF
--- a/sr_example/scripts/sr_example/hand_examples/sr_right_hand_follow_finger_trajectory.py
+++ b/sr_example/scripts/sr_example/hand_examples/sr_right_hand_follow_finger_trajectory.py
@@ -32,14 +32,10 @@ rospy.loginfo("\nMoving Index finger following a set of waypoints")
 
 waypoints = []
 
-# Move horizontally
-start_pose = geometry_msgs.msg.Pose()
-start_pose.position.x = 0.034
-start_pose.position.y = -0.002
-start_pose.position.z = 0.197
-start_pose.orientation.w = 1.00
+start_pose = hand_commander.get_current_pose(reference_frame=prefix + "_palm")
 waypoints.append(start_pose)
 
+# Move horizontally
 pose = geometry_msgs.msg.Pose()
 pose.position.x = 0.067
 pose.position.y = -0.010
@@ -59,26 +55,30 @@ waypoints.append(pose)
 waypoints.append(start_pose)
 
 # Move vertically
-pose = geometry_msgs.msg.Pose()
-pose.position.x = 0.033
-pose.position.y = -0.016
-pose.position.z = 0.190
-pose.orientation.w = 1.00
-waypoints.append(pose)
+pose1 = geometry_msgs.msg.Pose()
+pose1.position.x = 0.033
+pose1.position.y = -0.016
+pose1.position.z = 0.190
+pose1.orientation.w = 1.00
+waypoints.append(pose1)
 
-pose = geometry_msgs.msg.Pose()
-pose.position.x = 0.033
-pose.position.y = -0.035
-pose.position.z = 0.178
-pose.orientation.w = 1.00
-waypoints.append(pose)
+pose2 = geometry_msgs.msg.Pose()
+pose2.position.x = 0.033
+pose2.position.y = -0.035
+pose2.position.z = 0.178
+pose2.orientation.w = 1.00
+waypoints.append(pose2)
 
-pose = geometry_msgs.msg.Pose()
-pose.position.x = 0.033
-pose.position.y = -0.068
-pose.position.z = 0.151
-pose.orientation.w = 1.00
-waypoints.append(pose)
+pose3 = geometry_msgs.msg.Pose()
+pose3.position.x = 0.033
+pose3.position.y = -0.068
+pose3.position.z = 0.151
+pose3.orientation.w = 1.00
+waypoints.append(pose3)
+
+waypoints.append(pose2)
+
+waypoints.append(pose1)
 
 waypoints.append(start_pose)
 

--- a/sr_robot_commander/src/sr_robot_commander/grasp_saver_unsafe.py
+++ b/sr_robot_commander/src/sr_robot_commander/grasp_saver_unsafe.py
@@ -65,9 +65,9 @@ class SrGraspSaverUnsafe(object):
         if self.__hand_or_arm == "both":
             current_dict = self.__arm_commander.get_robot_state_bounded()
         elif self.__hand_or_arm == "arm":
-            current_dict = self.__arm_commander.get_current_pose_bounded()
+            current_dict = self.__arm_commander.get_current_state_bounded()
         elif self.__hand_or_arm == "hand":
-            current_dict = self.__hand_commander.get_current_pose_bounded()
+            current_dict = self.__hand_commander.get_current_state_bounded()
         else:
             rospy.logfatal("Unknown save type")
             exit(-1)

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -239,7 +239,7 @@ class SrRobotCommander(object):
                           " in " + reference_frame + " reference frame")
             return None
         else:
-            return self._move_group_commander.get_current_pose()
+            return self._move_group_commander.get_current_pose().pose
 
     def get_current_state(self):
         joint_names = self._move_group_commander._g.get_active_joints()

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -219,9 +219,9 @@ class SrRobotCommander(object):
     def get_current_pose(self, reference_frame=None):
         """
         Get the current pose of the end effector.
-        @param reference_frame - The desired reference frame in which end effector pose should be returned. 
+        @param reference_frame - The desired reference frame in which end effector pose should be returned.
         If none is passed, it will use the planning frame as reference.
-        @return geometry_msgs.msg.Pose() - current pose of the end effector 
+        @return geometry_msgs.msg.Pose() - current pose of the end effector
         """
         if reference_frame is not None:
             listener = tf.TransformListener()

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -259,7 +259,7 @@ class SrRobotCommander(object):
 
     def get_current_state_bounded(self):
         """
-        Get the current joint state of the group being used, checking that they are within each joint limits.
+        Get the current joint state of the group being used, enforcing that they are within each joint limits.
         @return a dictionary with the joint names as keys and current joint values
         """
         current = self._move_group_commander._g.get_current_state_bounded()

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -224,8 +224,8 @@ class SrRobotCommander(object):
                 listener.waitForTransform(reference_frame, self._move_group_commander.get_end_effector_link(),
                                           rospy.Time(0), rospy.Duration(5.0))
                 (trans, rot) = listener.lookupTransform(reference_frame,
-                                                       self._move_group_commander.get_end_effector_link(),
-                                                       rospy.Time(0))
+                                                        self._move_group_commander.get_end_effector_link(),
+                                                        rospy.Time(0))
                 current_pose.position.x = trans[0]
                 current_pose.position.y = trans[1]
                 current_pose.position.z = trans[2]

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -221,9 +221,9 @@ class SrRobotCommander(object):
         if reference_frame is not None:
             listener = tf.TransformListener()
             try:
-                listener.waitForTransform(reference_frame, self._move_group_commander.get_end_effector_link(), 
+                listener.waitForTransform(reference_frame, self._move_group_commander.get_end_effector_link(),
                                           rospy.Time(0), rospy.Duration(5.0))
-                (trans,rot) = listener.lookupTransform(reference_frame, 
+                (trans, rot) = listener.lookupTransform(reference_frame,
                                                        self._move_group_commander.get_end_effector_link(),
                                                        rospy.Time(0))
                 current_pose.position.x = trans[0]
@@ -236,7 +236,7 @@ class SrRobotCommander(object):
                 return current_pose
             except (tf.Exception, tf.LookupException, tf.ConnectivityException, tf.ExtrapolationException):
                 rospy.logwarn("Couldn't get the pose from " + self._move_group_commander.get_end_effector_link() +
-                          " in " + reference_frame + " reference frame")
+                              " in " + reference_frame + " reference frame")
             return None
         else:
             return self._move_group_commander.get_current_pose().pose

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -217,7 +217,12 @@ class SrRobotCommander(object):
         return output
 
     def get_current_pose(self, reference_frame=None):
-        current_pose = geometry_msgs.msg.Pose()
+        """
+        Get the current pose of the end effector.
+        @param reference_frame - The desired reference frame in which end effector pose should be returned. 
+        If none is passed, it will use the planning frame as reference.
+        @return geometry_msgs.msg.Pose() - current pose of the end effector 
+        """
         if reference_frame is not None:
             listener = tf.TransformListener()
             try:
@@ -226,6 +231,7 @@ class SrRobotCommander(object):
                 (trans, rot) = listener.lookupTransform(reference_frame,
                                                         self._move_group_commander.get_end_effector_link(),
                                                         rospy.Time(0))
+                current_pose = geometry_msgs.msg.Pose()
                 current_pose.position.x = trans[0]
                 current_pose.position.y = trans[1]
                 current_pose.position.z = trans[2]
@@ -242,12 +248,20 @@ class SrRobotCommander(object):
             return self._move_group_commander.get_current_pose().pose
 
     def get_current_state(self):
+        """
+        Get the current joint state of the group being used.
+        @return a dictionary with the joint names as keys and current joint values
+        """
         joint_names = self._move_group_commander._g.get_active_joints()
         joint_values = self._move_group_commander._g.get_current_joint_values()
 
         return dict(zip(joint_names, joint_values))
 
     def get_current_state_bounded(self):
+        """
+        Get the current joint state of the group being used, checking that they are within each joint limits.
+        @return a dictionary with the joint names as keys and current joint values
+        """
         current = self._move_group_commander._g.get_current_state_bounded()
         names = self._move_group_commander._g.get_active_joints()
         output = {n: current[n] for n in names if n in current}


### PR DESCRIPTION
Fixes #104 

Renamed the current get_current_pose to get_current_state and replaced where it was used.

Created a new get_current_pose to actually get the pose of the end effector. It takes the reference frame as an argument. If it is given, it uses tf to find the pose if not it uses the default get_current_pose from moveit which uses the planning_frame as reference (/world)
