### PR TITLE
simple fix to allow robot commander to work with any robot

### DIFF
--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -53,7 +53,7 @@ class SrRobotCommander(object):
                         "right_hand": "rh_",
                         "left_hand": "lh_"}
 
-    def __init__(self, name):
+    def __init__(self, name, prefix=None):
         """
         Initialize MoveGroupCommander object
         @param name - name of the MoveIt group
@@ -84,7 +84,9 @@ class SrRobotCommander(object):
             'compute_fk', GetPositionFK)
 
         # prefix of the trajectory controller
-        if name in self.__group_prefixes.keys():
+        if prefix is not None:
+            self._prefix = prefix
+        elif name in self.__group_prefixes.keys():
             self._prefix = self.__group_prefixes[name]
         else:
             # Group name is one of the ones to plan for specific fingers.


### PR DESCRIPTION
There is now an optional argument to the constructor allowing the user to manually specify a prefix for the trajectory controller.
