### PR TITLE
fixed namespace and added new param

### DIFF
--- a/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
@@ -13,7 +13,7 @@
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
-  <param name="trajectory_execution/allowed_start_tolerance" value="0.02"/> <!-- default 0.01 -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="0.03"/> <!-- default 0.01 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="shadowhand_motor" />

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
@@ -9,9 +9,11 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="shadowhand_motor" />

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
@@ -13,7 +13,7 @@
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
-  <param name="trajectory_execution/allowed_start_tolerance" value="0.01"/> <!-- default 0.01 -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="0.02"/> <!-- default 0.01 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="shadowhand_motor" />


### PR DESCRIPTION
Fixed a warning:
```
Deprecation warning: parameter 'allowed_execution_duration_scaling' moved into namespace 'trajectory_execution'.
Please, adjust file trajectory_execution.launch.xml!
```

And added the allowed_start_tolerance param