### PR TITLE
removed lma_kinematics_plugin from repository.rosinstall

### DIFF
--- a/repository.rosinstall
+++ b/repository.rosinstall
@@ -29,11 +29,6 @@
     version: kinetic-devel
 
 - git:
-    local-name: lma_kinematics_plugin
-    uri: https://github.com/shadow-robot/lma_kinematics_plugin
-    version: F_fixing_kinetic_build
-
-- git:
     local-name: shadow_robot_ethercat
     uri: https://github.com/shadow-robot/sr-ros-interface-ethercat.git
     version: kinetic-devel


### PR DESCRIPTION
Seems like this dependency is not needed. Built the package without it and can't find in sr_interface any include's for the package contents