### PR TITLE
Change urdf_parser_py import to upstream version

### DIFF
--- a/sr_moveit_hand_config/scripts/sr_moveit_hand_config/generate_hand_srdf.py
+++ b/sr_moveit_hand_config/scripts/sr_moveit_hand_config/generate_hand_srdf.py
@@ -45,7 +45,7 @@ import rospkg
 from xacro import set_substitution_args_context
 from rosgraph.names import load_mappings
 
-from sr_utilities.local_urdf_parser_py import URDF
+from urdf_parser_py.urdf import URDF
 
 
 class SRDFHandGenerator(object):

--- a/sr_moveit_hand_config/scripts/sr_moveit_hand_config/generate_moveit_config.py
+++ b/sr_moveit_hand_config/scripts/sr_moveit_hand_config/generate_moveit_config.py
@@ -47,7 +47,7 @@ import rospy
 import rosparam
 from srdfdom.srdf import SRDF
 
-from sr_utilities.local_urdf_parser_py import URDF
+from urdf_parser_py.urdf import URDF
 
 
 def yaml_reindent(in_str, numspaces):

--- a/sr_moveit_hand_config/scripts/sr_moveit_hand_config/virtual_joint_broadcaster.py
+++ b/sr_moveit_hand_config/scripts/sr_moveit_hand_config/virtual_joint_broadcaster.py
@@ -4,7 +4,7 @@
 
 import rospy
 import tf
-from sr_utilities.local_urdf_parser_py import URDF
+from urdf_parser_py.urdf import URDF
 
 
 def publish_world_to_base_transform():

--- a/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_moveit_config.py
+++ b/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_moveit_config.py
@@ -41,7 +41,7 @@ import rospkg
 import rosparam
 from srdfdom.srdf import SRDF
 
-from sr_utilities.local_urdf_parser_py import URDF
+from urdf_parser_py.urdf import URDF
 import generate_robot_srdf
 import sr_moveit_hand_config.generate_moveit_config as hand_config
 

--- a/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
+++ b/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
@@ -16,7 +16,7 @@ import xacro
 import rospy
 
 from sr_moveit_hand_config.generate_hand_srdf import SRDFHandGenerator
-from sr_utilities.local_urdf_parser_py import URDF
+from urdf_parser_py.urdf import URDF
 
 
 class SRDFRobotGeneratorException(Exception):

--- a/sr_multi_moveit/sr_multi_moveit_config/scripts/virtual_joint_broadcaster.py
+++ b/sr_multi_moveit/sr_multi_moveit_config/scripts/virtual_joint_broadcaster.py
@@ -4,7 +4,7 @@
 
 import rospy
 import tf
-from sr_utilities.local_urdf_parser_py import URDF
+from urdf_parser_py.urdf import URDF
 
 
 def publish_world_to_base_transform():

--- a/sr_multi_moveit/sr_multi_moveit_test/test/test_biotac_collada_name.py
+++ b/sr_multi_moveit/sr_multi_moveit_test/test/test_biotac_collada_name.py
@@ -3,7 +3,7 @@
 import sys
 import os
 from xml.dom.minidom import parse
-from sr_utilities.local_urdf_parser_py import URDF
+from urdf_parser_py.urdf import URDF
 import xacro
 import rospy
 import rospkg


### PR DESCRIPTION
This relates to the issue [change hand_finder back to use urdfdom instead of local copy after new release of urdfdom #19](https://github.com/shadow-robot/sr_core/issues/19) in the sr_core repo.

The local version of the urdf parser was added because the upstream version
didn't handle hardwareInterfaces in the transmission joints and actuators.

Since the changes of [fixed transmission parser to match specification #68](https://github.com/ros/urdfdom/pull/68), the upstream urdf parser handles TransmissionJoints with optional hardwareInterface elements.

Hardware interfaces in the actuator element shouldn't be used anymore and
are not used in the shadow repos.