### PR TITLE
Changes for SAT

### DIFF
--- a/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/trajectory_execution.launch.xml
@@ -13,7 +13,7 @@
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
   <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
   <!-- Allowed joint-value tolerance for validation that trajectory's first point matches current robot state -->
-  <param name="trajectory_execution/allowed_start_tolerance" value="0.03"/> <!-- default 0.01 -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="6.0"/> <!-- default 0.01 -->
   
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="shadowhand_motor" />

--- a/sr_robot_launch/launch/sr_right_ur10arm_hand.launch
+++ b/sr_robot_launch/launch/sr_right_ur10arm_hand.launch
@@ -27,6 +27,10 @@
   <arg name="robot_description" default="$(find sr_multi_description)/urdf/right_srhand_ur10_joint_limited.urdf.xacro"/>
   <arg name="robot_config_file" default="$(find sr_multi_moveit_config)/config/robot_configs/right_sh_ur10.yaml"/>
 
+  <!-- When true, robot_state_publisher publishes static frames to /tf_static. This can cause problems with the current rospy tf API,
+       which can't see /tf_static due to a bug (that will be fixed by https://github.com/ros/geometry/pull/134 once merged). -->
+  <arg name="use_tf_static" default="true"/>
+
   <arg name="side" value="right"/>
   <include file="$(find sr_robot_launch)/launch/sr_ur_arm_hand.launch">
     <arg name="sim" value="$(arg sim)"/>
@@ -49,5 +53,6 @@
     <arg name="hand_serial" value="$(arg hand_serial)"/>
     <arg name="mapping_path" value="$(arg mapping_path)"/>
     <arg name="eth_port" value="$(arg eth_port)"/>
+    <arg name="use_tf_static" value="$(arg use_tf_static)"/>
   </include>
 </launch>

--- a/sr_robot_launch/launch/sr_ur_arm_hand.launch
+++ b/sr_robot_launch/launch/sr_ur_arm_hand.launch
@@ -52,6 +52,10 @@
        More than one interface can be specified by concatenating them using underscore as a separator (e.g eth1_eth2_eth3) -->
   <arg name="eth_port" default="$(optenv ETHERCAT_PORT eth0)"/>
 
+  <!-- When true, robot_state_publisher publishes static frames to /tf_static. This can cause problems with the current rospy tf API,
+       which can't see /tf_static due to a bug (that will be fixed by https://github.com/ros/geometry/pull/134 once merged). -->
+  <arg name="use_tf_static" default="true"/>
+
   <!-- SIMULATED ROBOTS -->
   <group if="$(arg sim)">
     <arg name="paused" value="false"/>
@@ -78,6 +82,7 @@
     <node pkg="robot_state_publisher" type="robot_state_publisher" name="robot_state_publisher">
       <param name="publish_frequency" type="double" value="50.0" />
       <param name="tf_prefix" type="string" value="" />
+      <param name="use_tf_static" type="bool" value="$(arg use_tf_static)"/>
     </node>
   </group>
 


### PR DESCRIPTION
The changes to the robot_launch parameters are simple and won't affect anything else (the default value of robot_state_publisher's use_tf_static is maintained).

However I understand that the increase in trajectory_execution/allowed_start_tolerance is contentious. I can't see another way to get grasping to work on sr_interface:kinetic-devel though. @toliver, @beatrizleon, thoughts?