### PR TITLE
move_to_pose_value_target_unsafe was not working for just the arm

### DIFF
--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -215,6 +215,7 @@ class SrRobotCommander(object):
             for n, this_name in enumerate(joints):
                 if this_name in active_names:
                     js[this_name] = positions[n]
+            print "home state", js
             self._move_group_commander.set_joint_value_target(js)
         else:
             rospy.logerr("Unknown named state '%s'..." % name)
@@ -734,8 +735,12 @@ class SrRobotCommander(object):
 
     def move_to_pose_value_target_unsafe(self, target_pose,  avoid_collisions=False, time=0.002, wait=True):
         joint_state = self.get_ik(target_pose, avoid_collisions)
+        active_joints = self._move_group_commander.get_active_joints()
+        current_indices = [i for i, x in enumerate(joint_state.name) if any(thing in x for thing in active_joints)]
         if joint_state is not None:
-            state_as_dict = dict(zip(joint_state.name, joint_state.position))
+            current_names = [joint_state.name[i] for i in current_indices]
+            current_positions = [joint_state.position[i] for i in current_indices]
+            state_as_dict = dict(zip(current_names, current_positions))
             self.move_to_joint_value_target_unsafe(state_as_dict,
                                                    time=time,
                                                    wait=wait)

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -215,7 +215,6 @@ class SrRobotCommander(object):
             for n, this_name in enumerate(joints):
                 if this_name in active_names:
                     js[this_name] = positions[n]
-            print "home state", js
             self._move_group_commander.set_joint_value_target(js)
         else:
             rospy.logerr("Unknown named state '%s'..." % name)


### PR DESCRIPTION
Error ```Joints on incoming goal don't match the controller joints.``` as it was sending whole robot jonts for just the arm group. 