### PR TITLE
Adding single UR10 and BTSP biotac config.

### DIFF
--- a/sr_multi_moveit/sr_multi_moveit_config/config/robot_configs/right_sh_ur10_btsp_biotac.yaml
+++ b/sr_multi_moveit/sr_multi_moveit_config/config/robot_configs/right_sh_ur10_btsp_biotac.yaml
@@ -1,0 +1,17 @@
+robot:
+  name: ur10srh
+  manipulators:
+    right_manipulator:
+      side: right
+      arm:
+        name: ur10
+        main_group: manipulator
+        moveit_path: 
+          package: sr_multi_moveit_config
+          relative_path: /config/ur
+        extra_groups_config_path: /config
+        group_states:
+          - home
+          - up
+      hand:
+        name: shadowhand_motor_btsp.urdf.xacro


### PR DESCRIPTION
This was needed to have a BTSP (actually BTTB, but equivalent) Biotac hand on a single UR10.