### PR TITLE
F#src 224 fixed trajectory planning kinetic

### DIFF
--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -426,7 +426,7 @@ class SrRobotCommander(object):
 
         current_waypoint = {
             'joint_angles': [],
-            'interpolate_time': 0.001,
+            'interpolate_time': 0.01,
             'pause_time': 0.0
         }
         # SRC-224: Bug Fix

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -424,7 +424,16 @@ class SrRobotCommander(object):
 
         time_from_start = 0.0
 
-        for wp in trajectory:
+        current_waypoint = {
+            'joint_angles': [],
+            'interpolate_time': 0.001,
+            'pause_time': 0.0
+        }
+        # SRC-224: Bug Fix
+        # We create a first trajectory point corresponding to the current position to avoid moveit complaining about it
+        waypoints = [current_waypoint] + trajectory
+
+        for wp in waypoints:
 
             joint_positions = None
             if 'name' in wp.keys():


### PR DESCRIPTION
interpolate_time: 0.001 is causing this error: "Trajectory message contains waypoints that are not strictly increasing in time."
So I set it to 0.01 and it works in Hand E simulation