### PR TITLE
reduce longest_valid_segment_fraction to useful values

### DIFF
--- a/sr_moveit_hand_config/config/ompl_planning_template.yaml
+++ b/sr_moveit_hand_config/config/ompl_planning_template.yaml
@@ -81,7 +81,7 @@ first_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(FFJ4,FFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 middle_finger:
   planner_configs:
     - SBLkConfigDefault
@@ -96,7 +96,7 @@ middle_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(MFJ4,MFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 ring_finger:
   planner_configs:
     - SBLkConfigDefault
@@ -111,7 +111,7 @@ ring_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(RFJ4,RFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 little_finger:
   planner_configs:
     - SBLkConfigDefault
@@ -126,7 +126,7 @@ little_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(LFJ5,LFJ4)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 thumb:
   planner_configs:
     - SBLkConfigDefault
@@ -141,7 +141,7 @@ thumb:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(THJ5,THJ4)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 fingers:
   planner_configs:
     - SBLkConfigDefault
@@ -156,5 +156,5 @@ fingers:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(FFJ4,FFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.002
 


### PR DESCRIPTION
This gets rid of obviously colliding trajectories
generated by moveit's OMPL-based planner.

This value specifies how often OMPL does collision checks
on intermediate waypoints when sampling for a solution trajectory.
These are the only checks performed during planning, so we have
to check often enough to ensure we will not collide (badly).

The fraction value can be converted into a sum of angles by multiplication
with the maximum L0-norm between states in the respective planning group.
OMPL planning also applies L0-norm for the distance checks mentioned above.

With the Shadow hand, the collision that is easiest to miss
is a small motion in one of the j4 joints in my experience.
To catch those we should check at least every 5 degrees in L0 distance
between joint state changes - in the worst case only one j4 joint has moved.

For the different joint groups this threshold breaks down as follows
(all values in °):

wrist:

5/(36+68) = 0.0481

thumb:

5/(90+60+24+70+120) = 0.0137

ff/mf/rf:

5/(90+90+90+40) = 0.0161

lf:

5/(90+90+90+40+45) = 0.0141

fingers:

5/((90+90+90+40)*4+45+90+60+24+70+120) = 0.0030

I generously rounded down in each case.