### PR TITLE
provide ompl configuration for left/right_hand 

### DIFF
--- a/sr_moveit_hand_config/config/ompl_planning_template.yaml
+++ b/sr_moveit_hand_config/config/ompl_planning_template.yaml
@@ -81,7 +81,7 @@ first_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(FFJ4,FFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 middle_finger:
   planner_configs:
     - SBLkConfigDefault
@@ -96,7 +96,7 @@ middle_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(MFJ4,MFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 ring_finger:
   planner_configs:
     - SBLkConfigDefault
@@ -111,7 +111,7 @@ ring_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(RFJ4,RFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 little_finger:
   planner_configs:
     - SBLkConfigDefault
@@ -126,7 +126,7 @@ little_finger:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(LFJ5,LFJ4)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 thumb:
   planner_configs:
     - SBLkConfigDefault
@@ -141,7 +141,7 @@ thumb:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(THJ5,THJ4)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.01
 fingers:
   planner_configs:
     - SBLkConfigDefault
@@ -156,5 +156,5 @@ fingers:
     - PRMkConfigDefault
     - PRMstarkConfigDefault
   projection_evaluator: joints(FFJ4,FFJ3)
-  longest_valid_segment_fraction: 0.05
+  longest_valid_segment_fraction: 0.002
 

--- a/sr_moveit_hand_config/config/ompl_planning_template.yaml
+++ b/sr_moveit_hand_config/config/ompl_planning_template.yaml
@@ -157,4 +157,17 @@ fingers:
     - PRMstarkConfigDefault
   projection_evaluator: joints(FFJ4,FFJ3)
   longest_valid_segment_fraction: 0.002
-
+hand:
+  planner_configs:
+    - SBLkConfigDefault
+    - ESTkConfigDefault
+    - LBKPIECEkConfigDefault
+    - BKPIECEkConfigDefault
+    - KPIECEkConfigDefault
+    - RRTkConfigDefault
+    - RRTConnectkConfigDefault
+    - RRTstarkConfigDefault
+    - TRRTkConfigDefault
+    - PRMkConfigDefault
+    - PRMstarkConfigDefault
+  longest_valid_segment_fraction: 0.001

--- a/sr_moveit_hand_config/scripts/sr_moveit_hand_config/generate_moveit_config.py
+++ b/sr_moveit_hand_config/scripts/sr_moveit_hand_config/generate_moveit_config.py
@@ -201,7 +201,12 @@ def generate_ompl_planning(robot,
     # for each group
     for group in robot.groups:
         # strip prefix if any
-        group_name = group.name[len(prefix):]
+        group_name = group.name
+        if re.match("^"+str(prefix), group.name) is not None:
+            group_name = group.name[len(prefix):]
+        elif group.name in ["left_hand", "right_hand"]:
+            group_name = "hand"
+
         if group_name in yamldoc:
             output_str += group.name + ":\n"
             group_config = yamldoc[group_name]


### PR DESCRIPTION
This pull-request includes #328 , but I raised them independently for separate discussion if needed.

Previously there was simply no configuration for
our group "right_hand" and adding one to the template
didn't work because of the assumption that there is a prefix for all groups.

I removed the assumption and provide a useful configuration
"hand" in the template that maps to left_hand/right_hand as required.

The important parameter here is again longest_valid_segment_fraction.
OMPL's default here is 0.01, which is awful for this group and results in
index/middle finger to move right through the thumb in planned trajectories.
0.001 is a reasonable value applying a 5° maximum L0 distance.