### PR TITLE
increase trajectory execution parameters

### DIFF
--- a/sr_moveit_hand_config/launch/trajectory_execution.launch.xml
+++ b/sr_moveit_hand_config/launch/trajectory_execution.launch.xml
@@ -7,10 +7,13 @@
   <param name="moveit_manage_controllers" value="$(arg moveit_manage_controllers)"/>
 
   <!-- When determining the expected duration of a trajectory, this multiplicative factor is applied to get the allowed duration of execution -->
-  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.2"/> <!-- default 1.2 -->
+  <param name="trajectory_execution/allowed_execution_duration_scaling" value="1.8"/> <!-- default 1.2 -->
   <!-- Allow more than the expected execution time before triggering a trajectory cancel (applied after scaling) -->
-  <param name="trajectory_execution/allowed_goal_duration_margin" value="0.5"/> <!-- default 0.5 -->
+  <param name="trajectory_execution/allowed_goal_duration_margin" value="1.0"/> <!-- default 0.5 -->
   
+  <!-- adjust start tolerance to noise level in position control -->
+  <param name="trajectory_execution/allowed_start_tolerance" value="0.1"/> <!-- default 0.01 -->
+
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="shadowhand_motor" />
   <include file="$(find sr_moveit_hand_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml" />

--- a/sr_moveit_hand_config/launch/trajectory_execution.launch.xml
+++ b/sr_moveit_hand_config/launch/trajectory_execution.launch.xml
@@ -17,5 +17,5 @@
   <!-- Load the robot specific controller manager; this sets the moveit_controller_manager ROS parameter -->
   <arg name="moveit_controller_manager" default="shadowhand_motor" />
   <include file="$(find sr_moveit_hand_config)/launch/$(arg moveit_controller_manager)_moveit_controller_manager.launch.xml" />
-  
+
 </launch>


### PR DESCRIPTION
Without these changes I regularly see MoveIt aborting trajectories because
they took too long to execute using the provided trajectory controller.
the joint will usually move to the correct ending position, but MoveIt aborts the execution action before that.

Additionally we recently added an allowed_start_tolerance parameter in MoveIt
to prevent execution of trajectories that start too far away from the current state.
Without increasing the value, e.g. clicking "plan" and a bit later "execute" in
the RViz Motion Planning display often fails to execute because noise moved
the joints too far away from the planned start state. 0.1 should still be safe
for the Shadow hand.