### PR TITLE
Fix name of gui arg in srhand.launch.

### DIFF
--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -83,7 +83,7 @@
   <!-- MOVEIT -->
   <group if="$(arg use_moveit)">
     <node pkg="sr_utilities_common" type="timed_roslaunch.sh" args="15 sr_moveit_hand_config moveit_planning_and_execution.launch
-      use_gui:=$(arg gui)" name="timed_roslaunch" output="screen"/>
+      gui:=$(arg gui)" name="timed_roslaunch" output="screen"/>
     <include file="$(find sr_moveit_hand_config)/launch/default_warehouse_db.launch"/>
   </group>
 


### PR DESCRIPTION
Currently, setting the "gui" argument from the command line to false does not suppress the Rviz GUI launched by the moveit launch file. This pull request changes the argument to the correct name so that gui:=false works for an arbitrary launch file.