### PR TITLE
Removed source code dependency

### DIFF
--- a/repository.rosinstall
+++ b/repository.rosinstall
@@ -47,10 +47,3 @@
     local-name: pysdf
     uri: https://github.com/andreasBihlmaier/pysdf.git
     version: master
-
-## TODO: when commit https://github.com/ros-controls/ros_controllers/commit/6bf1b9b2ad13c865028a43a0ca0c96398ae86446 is released on deb package remove ros_controllers from here.
-# The current binary release is 0.13.3. When a new version is available, testing that the cyberglove runs comfortably without crashing the driver will tell if the issue is fixed.
-- git:
-    local-name: ros_controllers
-    uri: https://github.com/ros-controls/ros_controllers.git
-    version: kinetic-devel


### PR DESCRIPTION
Before merging please check if the cyberglove runs comfortably without crashing the driver will tell if the issue is fixed. This could be tested in simulation just cyberglove is needed.

Current binary version
ros-kinetic-ros-controllers:
  Installed: (none)
  Candidate: 0.13.5-0xenial-20190320-180510-0800
