### PR TITLE
Don't load ur10 kinematics_config without an arm

### DIFF
--- a/sr_robot_launch/launch/sr_hardware_control_loop.launch
+++ b/sr_robot_launch/launch/sr_hardware_control_loop.launch
@@ -48,7 +48,8 @@
   <!-- Set to true to spawn the position controllers for the arm-->
   <arg name="arm_position" default="$(eval not arm_trajectory)"/>
   <arg name="arm_speed_scale" default="0.5"/>
-  <arg name="kinematics_config" default="$(find ur_description)/config/ur10_default.yaml"/>
+  <arg if="$(arg arm)" name="kinematics_config" default="$(find ur_description)/config/ur10_default.yaml"/>
+  <arg unless="$(arg arm)" name="kinematics_config" default=""/>
   <arg name="urcap_program_name" default="external_ctrl.urp"/>
   <arg name="load_robot_description_command" default="xacro $(arg robot_description) prefix:=$(arg hand_id)_ initial_z:=$(arg initial_z) kinematics_config:=$(arg kinematics_config)"/>
 
@@ -64,7 +65,7 @@
   </group>
 
   <!-- So that the driver can check we're loading the right calibration -->
-  <rosparam command="load" file="$(arg kinematics_config)" ns="$(arg arm_prefix)_sr_ur_robot_hw"/>
+  <rosparam if="$(arg arm)" command="load" file="$(arg kinematics_config)" ns="$(arg arm_prefix)_sr_ur_robot_hw"/>
 
   <include file="$(find sr_robot_launch)/launch/unimanual_controller_stopper.launch">
     <arg name="side" value="$(arg side)"/>
@@ -132,7 +133,7 @@
   </rosparam>
 
   <!-- These will be loaded if hand is false so UR10 with box will load instead. -->
-  <group unless="$(arg hand)">
+  <group if="$(eval not arg('hand') and arg('arm'))">
     <include file="$(find ros_ethercat_model)/launch/joint_state_publisher.launch">
       <arg name="publish_rate" value="$(arg joint_state_pub_frequency)"/>
     </include>


### PR DESCRIPTION
## Proposed changes

The ur10 kinematics config should not be loaded if the shadow hand is used without an arm.
Without this patch you need a custom ur_description package in your workspace even if you don't use it.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Checklist
- [ ] Read and follow the [contributing guidelines](https://github.com/shadow-robot/sr_documentation/blob/master/CONTRIBUTING.md).
- [ ] Checked that all tests pass with my changes
- [ ] Added tests (automatic or manual) that prove the fix is effective or that the feature works
- [ ] Added necessary documentation (if appropriate)
- [ ] Added the corresponding license to each file and add the current year of any one that you modified.
- [x] Tested on real hardware (if appropriate)
￼

@v4hn 
