### PR TITLE
Adding the planning group two_hands

### DIFF
--- a/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
+++ b/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
@@ -482,9 +482,9 @@ class SRDFRobotGenerator(object):
         new_group = xml.dom.minidom.Document().createElement('group')
         new_group.setAttribute("name", "two_hands")
         hand_group_1 = xml.dom.minidom.Document().createElement('group name="' + group_1 + '"')
-        new_group.appendChild(arm_group_1)
+        new_group.appendChild(hand_group_1)
         hand_group_2 = xml.dom.minidom.Document().createElement('group name="' + group_2 + '"')
-        new_group.appendChild(arm_group_2)
+        new_group.appendChild(hand_group_2)
         new_group.writexml(self.new_robot_srdf, indent="  ", addindent="  ", newl="\n")
 
     def parse_hand_groups(self, manipulator_id, manipulator):

--- a/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
+++ b/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
@@ -230,7 +230,7 @@ class SRDFRobotGenerator(object):
             if manipulator.has_hand:
                 self.parse_hand_groups(manipulator_id, manipulator)
 
-        # Add groups for bimanual arm system
+        # Add groups for bimanual arm and hand systems
         if len(self.robot.manipulators) == 2:
             if self.robot.manipulators[0].has_arm and self.robot.manipulators[1].has_arm:
                 if self.robot.manipulators[0].has_hand and self.robot.manipulators[1].has_hand:
@@ -242,6 +242,11 @@ class SRDFRobotGenerator(object):
                     self.add_bimanual_arm_groups(self.robot.manipulators[0].arm.internal_name,
                                                  self.robot.manipulators[1].arm.internal_name,
                                                  False)
+                self.add_comments(comment)
+            if self.robot.manipulators[0].has_hand and self.robot.manipulators[1].has_hand:
+                comment = ["Bimanual groups with hands"]
+                self.add_bimanual_hand_groups(self.robot.manipulators[0].hand.internal_name,
+                                              self.robot.manipulators[1].hand.internal_name)
                 self.add_comments(comment)
 
         for manipulator_id, manipulator in enumerate(self.robot.manipulators):
@@ -472,6 +477,15 @@ class SRDFRobotGenerator(object):
             arm_group_2 = xml.dom.minidom.Document().createElement('group name="' + group_2 + '_and_hand"')
             new_group.appendChild(arm_group_2)
             new_group.writexml(self.new_robot_srdf, indent="  ", addindent="  ", newl="\n")
+
+    def add_bimanual_hand_groups(self, group_1, group_2):
+        new_group = xml.dom.minidom.Document().createElement('group')
+        new_group.setAttribute("name", "two_hands")
+        arm_group_1 = xml.dom.minidom.Document().createElement('group name="' + group_1 + '"')
+        new_group.appendChild(arm_group_1)
+        arm_group_2 = xml.dom.minidom.Document().createElement('group name="' + group_2 + '"')
+        new_group.appendChild(arm_group_2)
+        new_group.writexml(self.new_robot_srdf, indent="  ", addindent="  ", newl="\n")
 
     def parse_hand_groups(self, manipulator_id, manipulator):
         previous = self.hand_srdf_xmls[manipulator_id].documentElement

--- a/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
+++ b/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
@@ -481,9 +481,9 @@ class SRDFRobotGenerator(object):
     def add_bimanual_hand_groups(self, group_1, group_2):
         new_group = xml.dom.minidom.Document().createElement('group')
         new_group.setAttribute("name", "two_hands")
-        arm_group_1 = xml.dom.minidom.Document().createElement('group name="' + group_1 + '"')
+        hand_group_1 = xml.dom.minidom.Document().createElement('group name="' + group_1 + '"')
         new_group.appendChild(arm_group_1)
-        arm_group_2 = xml.dom.minidom.Document().createElement('group name="' + group_2 + '"')
+        hand_group_2 = xml.dom.minidom.Document().createElement('group name="' + group_2 + '"')
         new_group.appendChild(arm_group_2)
         new_group.writexml(self.new_robot_srdf, indent="  ", addindent="  ", newl="\n")
 


### PR DESCRIPTION
## Proposed changes

Please explain the changes you made. Add pictures or videos to explain them better if appropriate.

Adding the planning group two_hands as there is already two_arms and two_arms_and_hands . Needed for https://shadowrobot.atlassian.net/browse/SRC-5728 and is also good for productisation for a customer with bimanual hands

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [ ] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
