### PR TITLE
Adding x and y separations to launch and xacros

### DIFF
--- a/sr_multi_description/urdf/left_srhand_lite_ur5.urdf.xacro
+++ b/sr_multi_description/urdf/left_srhand_lite_ur5.urdf.xacro
@@ -1,7 +1,10 @@
-<robot xmlns:xacro="http://ros.org/wiki/xacro" name="ur10srh">
+<robot xmlns:xacro="http://ros.org/wiki/xacro" name="ur5srh">
 
     <!--<xacro:include filename="$(find ur_description)/urdf/gazebo.urdf.xacro" />-->
-    <xacro:include filename="$(find ur_description)/urdf/ur10.urdf.xacro"/>
+    <xacro:include filename="$(find ur_description)/urdf/ur5.urdf.xacro"/>
+    <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur5_default.yaml"/>
+    <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
+
     <link name="world"/>
     <xacro:arg name="initial_z" default="0.0"/>
     <xacro:arg name="arm_x_separation" default="0.0"/>
@@ -13,17 +16,16 @@
         <origin xyz="$(arg arm_x_separation) $(arg arm_y_separation) $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
     </joint>
 
-    <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur10_default.yaml"/>
+    <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur5_default.yaml"/>
     <xacro:arg name="transmission_hw_interface" default="hardware_interface/PositionJointInterface"/>
 
-    <xacro:ur10_robot prefix="la_" joint_limited="false" transmission_hw_interface="$(arg transmission_hw_interface)" kinematics_file="${load_yaml('$(arg kinematics_config)')}"/>
+    <xacro:ur5_robot prefix="la_" joint_limited="false" transmission_hw_interface="$(arg transmission_hw_interface)" kinematics_file="${load_yaml('$(arg kinematics_config)')}"/>
 
     <xacro:include filename="$(find sr_description)/materials.urdf.xacro"/>
-    <xacro:include filename="$(find sr_description)/hand/xacro/full_hand.urdf.xacro"/>
+    <xacro:include filename="$(find sr_description)/hand/xacro/hand_lite.urdf.xacro"/>
     <xacro:include filename="$(find sr_description)/other/xacro/gazebo/gazebo.urdf.xacro"/>
 
-    <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false" ubi="false" eli="false"
-                      reflect="-1.0" prefix="lh_" lf="true" cable_mesh="true"/>
+    <xacro:shadowhand muscletrans="false" muscle="false" bio="false" bt_sp="false" ubi="false" eli="false" reflect="-1.0" prefix="lh_" extra_lite="false"/>
 
     <joint name="la_arm_to_hand" type="fixed">
         <parent link="la_ee_link"/>

--- a/sr_multi_description/urdf/left_srhand_lite_ur5e.urdf.xacro
+++ b/sr_multi_description/urdf/left_srhand_lite_ur5e.urdf.xacro
@@ -6,11 +6,13 @@
 
     <link name="world"/>
     <xacro:arg name="initial_z" default="0.0"/>
+    <xacro:arg name="arm_x_separation" default="0.0"/>
+    <xacro:arg name="arm_y_separation" default="0.0"/>
 
     <joint name="world_joint" type="fixed">
         <parent link="world"/>
         <child link="la_base_link"/>
-        <origin xyz="0.0 0.0 $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
+        <origin xyz="$(arg arm_x_separation) $(arg arm_y_separation) $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
     </joint>
 
     <xacro:ur5e_robot prefix="la_" joint_limited="false" transmission_hw_interface="$(arg transmission_hw_interface)" kinematics_file="${load_yaml('$(arg kinematics_config)')}"/>

--- a/sr_multi_description/urdf/left_srhand_ur10_bt_sp_biotacs.urdf.xacro
+++ b/sr_multi_description/urdf/left_srhand_ur10_bt_sp_biotacs.urdf.xacro
@@ -4,11 +4,13 @@
     <xacro:include filename="$(find ur_description)/urdf/ur10.urdf.xacro"/>
     <link name="world"/>
     <xacro:arg name="initial_z" default="0.0"/>
+    <xacro:arg name="arm_x_separation" default="0.0"/>
+    <xacro:arg name="arm_y_separation" default="0.0"/>
 
     <joint name="world_joint" type="fixed">
         <parent link="world"/>
         <child link="la_base_link"/>
-        <origin xyz="0.0 0.0 $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
+        <origin xyz="$(arg arm_x_separation) $(arg arm_y_separation) $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
     </joint>
 
     <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur10_default.yaml"/>

--- a/sr_multi_description/urdf/left_srhand_ur10_joint_limited.urdf.xacro
+++ b/sr_multi_description/urdf/left_srhand_ur10_joint_limited.urdf.xacro
@@ -5,11 +5,13 @@
 
     <link name="world"/>
     <xacro:arg name="initial_z" default="0.0"/>
+    <xacro:arg name="arm_x_separation" default="0.0"/>
+    <xacro:arg name="arm_y_separation" default="0.0"/>
 
     <joint name="world_joint" type="fixed">
         <parent link="world"/>
         <child link="la_base_link"/>
-        <origin xyz="0.0 0.0 $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
+        <origin xyz="$(arg arm_x_separation) $(arg arm_y_separation) $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
     </joint>
 
     <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur10_default.yaml"/>

--- a/sr_multi_description/urdf/left_srhand_ur5.urdf.xacro
+++ b/sr_multi_description/urdf/left_srhand_ur5.urdf.xacro
@@ -4,11 +4,13 @@
     <xacro:include filename="$(find ur_description)/urdf/ur5.urdf.xacro"/>
     <link name="world"/>
     <xacro:arg name="initial_z" default="0.0"/>
+    <xacro:arg name="arm_x_separation" default="0.0"/>
+    <xacro:arg name="arm_y_separation" default="0.0"/>
 
     <joint name="world_joint" type="fixed">
         <parent link="world"/>
         <child link="la_base_link"/>
-        <origin xyz="0.0 0.0 $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
+        <origin xyz="$(arg arm_x_separation) $(arg arm_y_separation) $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
     </joint>
 
     <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur5_default.yaml"/>

--- a/sr_multi_description/urdf/left_srhand_ur5_joint_limited.urdf.xacro
+++ b/sr_multi_description/urdf/left_srhand_ur5_joint_limited.urdf.xacro
@@ -5,11 +5,13 @@
 
     <link name="world"/>
     <xacro:arg name="initial_z" default="0.0"/>
+    <xacro:arg name="arm_x_separation" default="0.0"/>
+    <xacro:arg name="arm_y_separation" default="0.0"/>
 
     <joint name="world_joint" type="fixed">
         <parent link="world"/>
         <child link="la_base_link"/>
-        <origin xyz="0.0 0.0 $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
+        <origin xyz="$(arg arm_x_separation) $(arg arm_y_separation) $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
     </joint>
 
     <xacro:arg name="kinematics_config" default="$(find ur_description)/config/ur5_default.yaml"/>

--- a/sr_multi_description/urdf/left_srhand_ur5e.urdf.xacro
+++ b/sr_multi_description/urdf/left_srhand_ur5e.urdf.xacro
@@ -6,11 +6,13 @@
 
     <link name="world"/>
     <xacro:arg name="initial_z" default="0.0"/>
+    <xacro:arg name="arm_x_separation" default="0.0"/>
+    <xacro:arg name="arm_y_separation" default="0.0"/>
 
     <joint name="world_joint" type="fixed">
         <parent link="world"/>
         <child link="la_base_link"/>
-        <origin xyz="0.0 0.0 $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
+        <origin xyz="$(arg arm_x_separation) $(arg arm_y_separation) $(arg initial_z)" rpy="0.0 0.0 ${pi}"/>
     </joint>
 
     <xacro:ur5e_robot prefix="la_" joint_limited="false" transmission_hw_interface="$(arg transmission_hw_interface)" kinematics_file="${load_yaml('$(arg kinematics_config)')}"/>

--- a/sr_multi_moveit/sr_multi_moveit_config/config/robot_configs/left_sh_lite_ur5.yaml
+++ b/sr_multi_moveit/sr_multi_moveit_config/config/robot_configs/left_sh_lite_ur5.yaml
@@ -1,0 +1,25 @@
+robot:
+  name: ur5srh
+  manipulators:
+    left_manipulator:
+      side: left
+      arm:
+        name: ur5
+        main_group: manipulator
+        moveit_path:
+          package: sr_multi_moveit_config
+          relative_path: /config/ur
+        extra_groups_config_path: /config
+        group_states:
+          - home
+          - up
+      hand:
+        name: shadowhand_left_lite.urdf.xacro
+        is_lite: true
+
+la_sr_ur_robot_hw:
+  # Hand G lite payload (estimated, need exact from Hardware)
+  payload_mass_kg: 2.4
+
+  # Hand G lite payload centre of inertia (estimated, need exact from Hardware)
+  payload_center_of_mass_m: [0.0, 0.0, 0.1]

--- a/sr_robot_launch/launch/sr_left_ur10arm_hand.launch
+++ b/sr_robot_launch/launch/sr_left_ur10arm_hand.launch
@@ -51,7 +51,8 @@
   <arg name="initial_z" default="0.7521" if="$(arg scene)"/>
   <arg name="initial_z" default="0.1" unless="$(arg scene)"/>
   <arg name="arm_x_separation" default="0.0"/>
-  <arg name="arm_y_separation" default="0.0"/>
+  <arg name="arm_y_separation" default="1.5" if="$(arg scene)"/>
+  <arg name="arm_y_separation" default="0.0" unless="$(arg scene)"/>
   <!-- You can select ur10 or ur10e -->
   <arg name="robot_model" default="ur10e"/>
   <arg name="arm_robot_hw" if="$(eval not arg('robot_model') == 'ur10e')" default="$(find sr_robot_launch)/config/left_ur_arm_robot_hw.yaml"/>

--- a/sr_robot_launch/launch/sr_left_ur5arm_hand.launch
+++ b/sr_robot_launch/launch/sr_left_ur5arm_hand.launch
@@ -50,6 +50,9 @@
   <!-- ARM CONFIG-->
   <arg name="initial_z" default="0.7521" if="$(arg scene)"/>
   <arg name="initial_z" default="0.1" unless="$(arg scene)"/>
+  <arg name="arm_x_separation" default="0.0"/>
+  <arg name="arm_y_separation" default="1.5" if="$(arg scene)"/>
+  <arg name="arm_y_separation" default="0.0" unless="$(arg scene)"/>
   <!-- You can select ur5 or ur5e -->
   <arg name="robot_model" default="ur5e"/>
   <arg name="arm_robot_hw" default="$(find sr_robot_launch)/config/left_ur_arm_robot_hw.yaml"/>
@@ -80,6 +83,8 @@
     <arg name="hand_type" value="$(arg hand_type)"/>
 
     <arg name="initial_z" value="$(arg initial_z)"/>
+    <arg name="arm_x_separation" value="$(arg arm_x_separation)"/>
+    <arg name="arm_y_separation" value="$(arg arm_y_separation)"/>
     <arg name="arm_robot_hw" value="$(arg arm_robot_hw)"/>
     <arg name="arm_trajectory" default="$(arg arm_trajectory)"/>
     <arg name="arm_position" default="$(arg arm_position)"/>


### PR DESCRIPTION
## Proposed changes

Adding x and y separations to xacros and updating launch files so that left is on the left stand.

https://shadowrobot.atlassian.net/browse/SRC-5618


## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
