### PR TITLE
SRC-5987 Publish underactuation error

### DIFF
--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -5,20 +5,34 @@ project(sr_error_reporter)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
+  geometry_msgs
   eigen_conversions
   genmsg
   moveit_core
-  moveit_ros_planning_interface)
+  moveit_ros_planning_interface
+  message_generation)
 
-## Declare ROS messages and services
-#add_message_files(DIRECTORY msg FILES Num.msg)
-#add_service_files(DIRECTORY srv FILES AddTwoInts.srv)
-
-## Generate added messages and services
-#generate_messages(DEPENDENCIES std_msgs)
+  add_message_files(
+    FILES
+    UnderactuationError.msg
+  )
+  
+  generate_messages(
+    DEPENDENCIES
+    std_msgs
+    geometry_msgs
+  )
 
 ## Declare a catkin package
-catkin_package()
+catkin_package(
+  LIBRARIES ${PROJECT_NAME}
+  CATKIN_DEPENDS
+    roscpp
+    std_msgs
+    geometry_msgs
+    moveit_core
+    moveit_ros_planning_interface
+    message_runtime)
 
 include_directories(include ${catkin_INCLUDE_DIRS})
 

--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 2.8.3)
+project(sr_error_reporter)
+
+## Find catkin and any catkin packages
+find_package(catkin REQUIRED COMPONENTS
+  roscpp
+  std_msgs
+  genmsg
+  moveit_core
+  moveit_ros_planning_interface)
+
+## Declare ROS messages and services
+#add_message_files(DIRECTORY msg FILES Num.msg)
+#add_service_files(DIRECTORY srv FILES AddTwoInts.srv)
+
+## Generate added messages and services
+#generate_messages(DEPENDENCIES std_msgs)
+
+## Declare a catkin package
+catkin_package()
+
+include_directories(include ${catkin_INCLUDE_DIRS})
+
+add_executable(error_reporter
+  src/error_reporter.cpp
+  src/UnderactuationErrorReporter.cpp)
+target_link_libraries(error_reporter ${catkin_LIBRARIES})

--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -10,7 +10,8 @@ find_package(catkin REQUIRED COMPONENTS
   genmsg
   moveit_core
   moveit_ros_planning_interface
-  message_generation)
+  message_generation
+  sr_utilities_common)
 
 add_message_files(
   FILES

--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -25,6 +25,7 @@ find_package(catkin REQUIRED COMPONENTS
 
 ## Declare a catkin package
 catkin_package(
+  INCLUDE_DIRS include
   LIBRARIES ${PROJECT_NAME}
   CATKIN_DEPENDS
     roscpp

--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -41,3 +41,4 @@ add_executable(error_reporter
   src/error_reporter.cpp
   src/UnderactuationErrorReporter.cpp)
 target_link_libraries(error_reporter ${catkin_LIBRARIES})
+add_dependencies(error_reporter error_reporter_generate_messages_cpp)

--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -12,16 +12,16 @@ find_package(catkin REQUIRED COMPONENTS
   moveit_ros_planning_interface
   message_generation)
 
-  add_message_files(
-    FILES
+add_message_files(
+  FILES
     UnderactuationError.msg
-  )
-  
-  generate_messages(
-    DEPENDENCIES
+)
+
+generate_messages(
+  DEPENDENCIES
     std_msgs
     geometry_msgs
-  )
+)
 
 ## Declare a catkin package
 catkin_package(

--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -5,6 +5,7 @@ project(sr_error_reporter)
 find_package(catkin REQUIRED COMPONENTS
   roscpp
   std_msgs
+  eigen_conversions
   genmsg
   moveit_core
   moveit_ros_planning_interface)

--- a/sr_error_reporter/CMakeLists.txt
+++ b/sr_error_reporter/CMakeLists.txt
@@ -41,4 +41,4 @@ add_executable(error_reporter
   src/error_reporter.cpp
   src/UnderactuationErrorReporter.cpp)
 target_link_libraries(error_reporter ${catkin_LIBRARIES})
-add_dependencies(error_reporter error_reporter_generate_messages_cpp)
+add_dependencies(error_reporter sr_error_reporter_generate_messages_cpp)

--- a/sr_error_reporter/README.md
+++ b/sr_error_reporter/README.md
@@ -17,7 +17,11 @@ only J1 and J2 joints for underactuated fingers are set to either actual or
 desired values. Then fingertip position is calculated by running forward
 kinematics. Cartesian distance between actual and desired fingertips is
 calculated and published to a topic per finger:
-* /underactuation_error/rh_fftip
-* /underactuation_error/rh_lftip
-* /underactuation_error/rh_mftip
-* /underactuation_error/rh_rftip
+* /sh_lh_ffj0_position_controller/underactuation_cartesian_error
+* /sh_lh_mfj0_position_controller/underactuation_cartesian_error
+* /sh_lh_rfj0_position_controller/underactuation_cartesian_error
+* /sh_lh_lfj0_position_controller/underactuation_cartesian_error
+* /sh_rh_ffj0_position_controller/underactuation_cartesian_error
+* /sh_rh_mfj0_position_controller/underactuation_cartesian_error
+* /sh_rh_rfj0_position_controller/underactuation_cartesian_error
+* /sh_rh_lfj0_position_controller/underactuation_cartesian_error

--- a/sr_error_reporter/README.md
+++ b/sr_error_reporter/README.md
@@ -9,14 +9,14 @@ rosrun sr_error_reporter error_reporter
 
 ## Underactuation error
 
-Underactuation error is calculated by listening to topic `/joint_states` for
-actual values from sensors and by listening to topics `/lh_trajectory_controller/command`
-and `/rh_trajectory_controller/command` for desired values.
-When one of these topics changes, kinematic model is reset to zeros and only J1
-and J2 joints for underactuated fingers are set to either actual or desired
-values. Then fingertip position is calculated by running forward kinemates.
-Cartesian distance between actual and desired fingertips are calculated and
-published to a topic per finger:
+Underactuation error is calculated by listening to topics
+`/lh_trajectory_controller/state` and `/rh_trajectory_controller/state` and
+comparing `actual.positions` field to `desired.positions` field.
+When one of these topics changes, the kinematic model is reset to zeros and
+only J1 and J2 joints for underactuated fingers are set to either actual or
+desired values. Then fingertip position is calculated by running forward
+kinematics. Cartesian distance between actual and desired fingertips is
+calculated and published to a topic per finger:
 * /underactuation_error/rh_fftip
 * /underactuation_error/rh_lftip
 * /underactuation_error/rh_mftip

--- a/sr_error_reporter/README.md
+++ b/sr_error_reporter/README.md
@@ -1,0 +1,23 @@
+# sr_error_reporter
+
+A package for calculating and publishing errors.
+
+This node can be started by:
+```
+rosrun sr_error_reporter error_reporter
+```
+
+## Underactuation error
+
+Underactuation error is calculated by listening to topic `/joint_states` for
+actual values from sensors and by listening to topics `/lh_trajectory_controller/command`
+and `/lh_trajectory_controller/command` for desired values.
+When one of these topics changes, kinematic model is reset to zeros and only J1
+and J2 joints for underactuated fingers are set to either actual or desired
+values. Then fingertip position is calculated by running forward kinemates.
+Cartesian distance between actual and desired fingertips are calculated and
+published to a topic per finger:
+* /underactuation_error/rh_fftip
+* /underactuation_error/rh_lftip
+* /underactuation_error/rh_mftip
+* /underactuation_error/rh_rftip

--- a/sr_error_reporter/README.md
+++ b/sr_error_reporter/README.md
@@ -11,7 +11,7 @@ rosrun sr_error_reporter error_reporter
 
 Underactuation error is calculated by listening to topic `/joint_states` for
 actual values from sensors and by listening to topics `/lh_trajectory_controller/command`
-and `/lh_trajectory_controller/command` for desired values.
+and `/rh_trajectory_controller/command` for desired values.
 When one of these topics changes, kinematic model is reset to zeros and only J1
 and J2 joints for underactuated fingers are set to either actual or desired
 values. Then fingertip position is calculated by running forward kinemates.

--- a/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
@@ -71,7 +71,9 @@ class UnderactuationErrorReporter
     "knuckle"
   };
 
-  ros::Publisher get_or_create_publisher(std::string link_name);
+  ros::Publisher get_or_create_publisher(
+    std::string side,
+    std::string finger_name);
 
   void update_kinematic_model(
     std::string side,
@@ -79,6 +81,7 @@ class UnderactuationErrorReporter
     std::map<std::string, geometry_msgs::Transform>& transforms);
 
   void publish_error(
+    std::string side,
     std::map<std::string, geometry_msgs::Transform> actual_tip_transforms,
     std::map<std::string, geometry_msgs::Transform> desired_tip_transforms);
 

--- a/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
@@ -38,7 +38,7 @@ class UnderactuationErrorReporter
   ros::NodeHandle& node_handle_;
   robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
   moveit::core::RobotStatePtr robot_state_;
-  ros::Subscriber joints_subsriber_, trajectory_subsriber_left_, trajectory_subsriber_right_;
+  ros::Subscriber joints_subscriber_, trajectory_subscriber_left_, trajectory_subscriber_right_;
   std::map<std::string, ros::Publisher> error_publishers_;
 
   /**

--- a/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
@@ -18,7 +18,6 @@
 #define SR_INTERFACE_SR_ERROR_REPORTER_SRC_UNDERACTUATIONERRORREPORTER_HPP_
 
 #include <map>
-#include <set>
 #include <string>
 #include <vector>
 
@@ -85,7 +84,7 @@ class UnderactuationErrorReporter
 
   /**
    * Update given joint position map with new value if joint name
-   * if for underactuated finger.
+   * is for underactuated finger.
    *
    * @param joint_positions Map of link name to position for updating.
    * @param name For example "rh_FFJ2".

--- a/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/include/sr_error_reporter/UnderactuationErrorReporter.hpp
@@ -1,6 +1,17 @@
 /*
-* Copyright (C) 2021 Shadow Robot Company Ltd - All Rights Reserved. Proprietary and Confidential.
-* Unauthorized copying of the content in this file, via any medium is strictly prohibited.
+* Copyright 2021 Shadow Robot Company Ltd.
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation version 2 of the License.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #ifndef SR_INTERFACE_SR_ERROR_REPORTER_SRC_UNDERACTUATIONERRORREPORTER_HPP_
@@ -77,7 +88,7 @@ class UnderactuationErrorReporter
     "knuckle"
   };
 
-  void add_side(std::string side);
+  ros::Publisher get_or_create_publisher(std::string link_name);
 
   void update_kinematic_model(
     std::map<std::string, double>& joint_positions,

--- a/sr_error_reporter/msg/UnderactuationError.msg
+++ b/sr_error_reporter/msg/UnderactuationError.msg
@@ -1,0 +1,5 @@
+# Header for timestamp etc.
+Header header
+
+# Distance between desired and actual fingertip
+float32 error

--- a/sr_error_reporter/package.xml
+++ b/sr_error_reporter/package.xml
@@ -15,6 +15,8 @@
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning_interface</depend>
   <depend>std_msgs</depend>
+  <depend>sr_utilities_common</depend>
+
   <build_depend>message_generation</build_depend>
 
   <exec_depend>message_runtime</exec_depend>

--- a/sr_error_reporter/package.xml
+++ b/sr_error_reporter/package.xml
@@ -10,6 +10,12 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>roscpp</depend>
+  <depend>geometry_msgs</depend>
   <depend>moveit_core</depend>
   <depend>moveit_ros_planning_interface</depend>
+  <depend>std_msgs</depend>
+  <build_depend>message_generation</build_depend>
+
+  <exec_depend>message_runtime</exec_depend>
 </package>

--- a/sr_error_reporter/package.xml
+++ b/sr_error_reporter/package.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>sr_error_reporter</name>
+  <version>0.1.0</version>
+  <description>Package for calculating and publishing various errors.</description>
+
+  <maintainer email="software@shadowrobot.com">Shadow Robot's software team</maintainer>
+
+  <license>Private</license>
+
+  <buildtool_depend>catkin</buildtool_depend>
+
+  <depend>moveit_core</depend>
+  <depend>moveit_ros_planning_interface</depend>
+</package>

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -3,23 +3,26 @@
 * Unauthorized copying of the content in this file, via any medium is strictly prohibited.
 */
 
+#include <eigen_conversions/eigen_msg.h>
+
 #include "UnderactuationErrorReporter.hpp"
 
 UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_handle)
-  : node_handle(node_handle)
+  : node_handle_(node_handle)
 {
-  joints_subsriber = node_handle.subscribe("/joint_states", 1,
+  joints_subsriber_ = node_handle.subscribe("/joint_states", 1,
     &UnderactuationErrorReporter::joints_callback, this, ros::TransportHints().tcpNoDelay());
-  trajectory_subsriber_left = node_handle.subscribe("/lh_trajectory_controller/command", 1,
+  trajectory_subsriber_left_ = node_handle.subscribe("/lh_trajectory_controller/command", 1,
     &UnderactuationErrorReporter::trajectory_callback, this, ros::TransportHints().tcpNoDelay());
-  trajectory_subsriber_right = node_handle.subscribe("/rh_trajectory_controller/command", 1,
+  trajectory_subsriber_right_ = node_handle.subscribe("/rh_trajectory_controller/command", 1,
     &UnderactuationErrorReporter::trajectory_callback, this, ros::TransportHints().tcpNoDelay());
   ROS_ERROR_STREAM("callback added");
 
   robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("robot_description"));
-  moveit::core::RobotModelPtr kinematic_model_ = robot_model_loader_->getModel();
+  robot_state_.reset(new robot_state::RobotState(robot_model_loader_->getModel()));
+  robot_state_->setToDefaultValues();
 
-  if (kinematic_model_ == NULL)
+  /*if (kinematic_model_ == NULL)
   {
     ROS_ERROR("No robot description found");
   }
@@ -33,22 +36,50 @@ UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_h
         ROS_ERROR_STREAM("\tLink name: " << link_name);
       }
     }
+  }*/
+}
+
+void UnderactuationErrorReporter::update_kinematic_model(
+  std::map<std::string, double>& joint_positions,
+  std::map<std::string, geometry_msgs::Transform>& transforms)
+{
+  robot_state_->setToDefaultValues();
+  for (auto& side : sides_)
+  {
+    for (auto& finger : include_fingers_)
+    {
+      std::vector<double> positions = {0, 0, 0.3, 0.4};
+      ROS_ERROR_STREAM("setJointGroupPositions START");
+      robot_state_->setJointGroupPositions("rh_first_finger", positions);
+      ROS_ERROR_STREAM("setJointGroupPositions END");
+    }
+  }
+  for (auto& side : sides_)
+  {
+    for (auto& finger : include_fingers_)
+    {
+      std::string link_name = side + finger + "tip";
+      const Eigen::Affine3d &end_effector_state = robot_state_->getGlobalLinkTransform(link_name);
+      geometry_msgs::Transform transform;
+      tf::transformEigenToMsg(end_effector_state, transform);
+      transforms[link_name] = transform;
+    }
   }
 }
 
 void UnderactuationErrorReporter::publish_error()
 {
   ROS_ERROR_STREAM("Actual:");
-  for (auto& joint : actual_joint_angles)
+  for (auto& joint : actual_joint_angles_)
   {
     ROS_ERROR_STREAM("\t" << joint.first << ": " << joint.second);
   }
   ROS_ERROR_STREAM("Desired:");
-  for (auto& joint : desired_joint_angles)
+  for (auto& joint : desired_joint_angles_)
   {
     ROS_ERROR_STREAM("\t" << joint.first << ": " << joint.second);
   }
-  // TODO: publish error
+  // TODO: calculate and publish error
 }
 
 void UnderactuationErrorReporter::update_joint_position(
@@ -60,34 +91,41 @@ void UnderactuationErrorReporter::update_joint_position(
   {
     return;
   }
+
   std::string finger_name = name.substr(3, 2);
-  if (include_fingers.find(finger_name) == include_fingers.end())
-  {
-    return;
-  }
   std::transform(finger_name.begin(), finger_name.end(), finger_name.begin(), [](unsigned char c)
   {
     return std::tolower(c);
   });
-  std::string side = name.substr(0, 3);
+  if (include_fingers_.find(finger_name) == include_fingers_.end())
+  {
+    return;
+  }
+
   int joint_index = std::atoi(name.substr(6, 1).c_str());
   if (joint_index > 0 && joint_index <= 4)
   {
-    joint_positions[side + finger_name + joint_names[joint_index]] = position;
+    std::string side = name.substr(0, 3);
+    sides_.insert(side);
+    joint_positions[side + finger_name + joint_names_[joint_index]] = position;
   }
 }
 
 void UnderactuationErrorReporter::joints_callback(const sensor_msgs::JointStateConstPtr& msg)
 {
   for (int i = 0; i < msg->name.size(); i++) {
-    update_joint_position(actual_joint_angles, msg->name[i], msg->position[i]);
+    update_joint_position(actual_joint_angles_, msg->name[i], msg->position[i]);
   }
+  update_kinematic_model(actual_joint_angles_, actual_tip_transforms_);
   publish_error();
 }
 
 void UnderactuationErrorReporter::trajectory_callback(const trajectory_msgs::JointTrajectory& msg) {
   for (int i = 0; i < msg.joint_names.size(); i++) {
-    update_joint_position(desired_joint_angles, msg.joint_names[i], msg.points[0].positions[i]);
+    if (msg.points.size() > 0) {
+      update_joint_position(desired_joint_angles_, msg.joint_names[i], msg.points[0].positions[i]);
+    }
   }
+  update_kinematic_model(desired_joint_angles_, desired_tip_transforms_);
   publish_error();
 }

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -22,7 +22,7 @@
 #include "eigen_conversions/eigen_msg.h"
 #include "sr_error_reporter/UnderactuationError.h"
 #include "std_msgs/String.h"
-
+#include "sr_error_reporter/UnderactuationError.h"
 #include "sr_error_reporter/UnderactuationErrorReporter.hpp"
 
 UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_handle)

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -14,7 +14,12 @@
 * with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
-#include <eigen_conversions/eigen_msg.h>
+#include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "eigen_conversions/eigen_msg.h"
 #include "sr_error_reporter/UnderactuationError.h"
 #include "std_msgs/String.h"
 
@@ -79,15 +84,17 @@ void UnderactuationErrorReporter::update_kinematic_model(
 
 void UnderactuationErrorReporter::publish_error()
 {
-  for (auto& actual : actual_tip_transforms_) {
+  for (auto& actual : actual_tip_transforms_)
+  {
     std::string link_name = actual.first;
     auto desired = desired_tip_transforms_.find(link_name);
-    if (desired != desired_tip_transforms_.end()) {
+    if (desired != desired_tip_transforms_.end())
+    {
       double x = actual.second.translation.x - desired->second.translation.x;
       double y = actual.second.translation.y - desired->second.translation.y;
       double z = actual.second.translation.z - desired->second.translation.z;
       double error = std::sqrt(x * x + y * y + z * z);
-      
+
       sr_error_reporter::UnderactuationError underactuation_error;
       underactuation_error.header.stamp = ros::Time::now();
       underactuation_error.error = error;
@@ -110,7 +117,8 @@ void UnderactuationErrorReporter::update_joint_position(
   std::transform(finger_name.begin(), finger_name.end(), finger_name.begin(), [](unsigned char c)
   {
     return std::tolower(c);
-  });
+  }
+  );
   if (include_fingers_.find(finger_name) == include_fingers_.end())
   {
     return;
@@ -127,7 +135,8 @@ void UnderactuationErrorReporter::update_joint_position(
 
 void UnderactuationErrorReporter::joints_callback(const sensor_msgs::JointStateConstPtr& msg)
 {
-  for (int i = 0; i < msg->name.size(); i++) {
+  for (int i = 0; i < msg->name.size(); i++)
+  {
     update_joint_position(actual_joint_angles_, msg->name[i], msg->position[i]);
   }
   update_kinematic_model(actual_joint_angles_, actual_tip_transforms_);
@@ -135,8 +144,10 @@ void UnderactuationErrorReporter::joints_callback(const sensor_msgs::JointStateC
 }
 
 void UnderactuationErrorReporter::trajectory_callback(const trajectory_msgs::JointTrajectory& msg) {
-  for (int i = 0; i < msg.joint_names.size(); i++) {
-    if (msg.points.size() > 0) {
+  for (int i = 0; i < msg.joint_names.size(); i++)
+  {
+    if (msg.points.size() > 0)
+    {
       update_joint_position(desired_joint_angles_, msg.joint_names[i], msg.points[0].positions[i]);
     }
   }

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -1,0 +1,89 @@
+/*
+* Copyright (C) 2021 Shadow Robot Company Ltd - All Rights Reserved. Proprietary and Confidential.
+* Unauthorized copying of the content in this file, via any medium is strictly prohibited.
+*/
+
+#include "UnderactuationErrorReporter.hpp"
+
+UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_handle)
+  : node_handle(node_handle)
+{
+  joints_subsriber = node_handle.subscribe("/joint_states", 1,
+    &UnderactuationErrorReporter::joints_callback, this, ros::TransportHints().tcpNoDelay());
+  trajectory_subsriber_left = node_handle.subscribe("/lh_trajectory_controller/command", 1,
+    &UnderactuationErrorReporter::trajectory_callback, this, ros::TransportHints().tcpNoDelay());
+  trajectory_subsriber_right = node_handle.subscribe("/rh_trajectory_controller/command", 1,
+    &UnderactuationErrorReporter::trajectory_callback, this, ros::TransportHints().tcpNoDelay());
+  ROS_ERROR_STREAM("callback added");
+
+  robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("robot_description"));
+  moveit::core::RobotModelPtr kinematic_model_ = robot_model_loader_->getModel();
+
+  if (kinematic_model_ == NULL)
+  {
+    ROS_ERROR("No robot description found");
+  }
+  else
+  {
+    ROS_ERROR("ROBOT FOUND!");
+    for (auto& group_name : kinematic_model_->getJointModelGroupNames()) {
+      ROS_ERROR_STREAM("Group name: " << group_name);
+      const robot_model::JointModelGroup *group = kinematic_model_->getJointModelGroup(group_name);
+      for (auto& link_name : group->getLinkModelNames()) {
+        ROS_ERROR_STREAM("\tLink name: " << link_name);
+      }
+    }
+  }
+}
+
+void UnderactuationErrorReporter::publish_error()
+{
+  ROS_ERROR_STREAM("Actual:");
+  for (auto& joint : actual_joint_angles)
+  {
+    ROS_ERROR_STREAM("\t" << joint.first << ": " << joint.second);
+  }
+  ROS_ERROR_STREAM("Desired:");
+  for (auto& joint : desired_joint_angles)
+  {
+    ROS_ERROR_STREAM("\t" << joint.first << ": " << joint.second);
+  }
+  // TODO: publish error
+}
+
+void UnderactuationErrorReporter::update_joint_position(
+  std::map<std::string, double>& joint_positions,
+  std::string name,
+  double position)
+{
+  if (name.size() >= 7)
+  {
+    std::string side = name.substr(0, 3);
+    std::string finger_name = name.substr(3, 2);
+    std::transform(finger_name.begin(), finger_name.end(), finger_name.begin(), [](unsigned char c)
+    {
+      return std::tolower(c);
+    });
+    // TODO: filter out thumb and wrist
+    int joint_index = std::atoi(name.substr(6, 1).c_str()) - 1;
+    if (joint_index >= 0 && joint_index <= 4)
+    {
+      joint_positions[side + finger_name + joint_names[joint_index]] = position;
+    }
+  }
+}
+
+void UnderactuationErrorReporter::joints_callback(const sensor_msgs::JointStateConstPtr& msg)
+{
+  for (int i = 0; i < msg->name.size(); i++) {
+    update_joint_position(actual_joint_angles, msg->name[i], msg->position[i]);
+  }
+  publish_error();
+}
+
+void UnderactuationErrorReporter::trajectory_callback(const trajectory_msgs::JointTrajectory& msg) {
+  for (int i = 0; i < msg.joint_names.size(); i++) {
+    update_joint_position(desired_joint_angles, msg.joint_names[i], msg.points[0].positions[i]);
+  }
+  publish_error();
+}

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -64,7 +64,17 @@ void UnderactuationErrorReporter::publish_error()
   {
     ROS_ERROR_STREAM("\t" << joint.first << ": " << joint.second);
   }
-  // TODO: calculate and publish error
+  for (auto& actual : actual_tip_transforms_) {
+    auto desired = desired_tip_transforms_.find(actual.first);
+    if (desired != desired_tip_transforms_.end()) {
+      double x = actual.second.translation.x - desired->second.translation.x;
+      double y = actual.second.translation.y - desired->second.translation.y;
+      double z = actual.second.translation.z - desired->second.translation.z;
+      double error = std::sqrt(x * x + y * y + z * z);
+      ROS_ERROR_STREAM("Error for " << actual.first << ": " << error);
+      // TODO: publish error
+    }
+  }
 }
 
 void UnderactuationErrorReporter::update_joint_position(

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -34,9 +34,18 @@ UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_h
   trajectory_subscriber_right_ = node_handle.subscribe("/rh_trajectory_controller/command", 1,
     &UnderactuationErrorReporter::trajectory_callback, this, ros::TransportHints().tcpNoDelay());
 
-  robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("robot_description"));
-  robot_state_.reset(new robot_state::RobotState(robot_model_loader_->getModel()));
-  robot_state_->setToDefaultValues();
+  while (ros::ok())
+  {
+    std::string robot_description;
+    if (node_handle.searchParam("robot_description_semantic", robot_description))
+    {
+      robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("robot_description"));
+      robot_state_.reset(new robot_state::RobotState(robot_model_loader_->getModel()));
+      break;
+    }
+    ROS_INFO("Waiting for robot description");
+    ros::Duration(1).sleep();
+  }
 }
 
 ros::Publisher UnderactuationErrorReporter::get_or_create_publisher(std::string link_name)

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -20,7 +20,6 @@
 #include <vector>
 
 #include "eigen_conversions/eigen_msg.h"
-#include "sr_error_reporter/UnderactuationError.h"
 #include "std_msgs/String.h"
 #include "sr_error_reporter/UnderactuationError.h"
 #include "sr_error_reporter/UnderactuationErrorReporter.hpp"

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -56,20 +56,24 @@ void UnderactuationErrorReporter::update_joint_position(
   std::string name,
   double position)
 {
-  if (name.size() >= 7)
+  if (name.size() < 7)
   {
-    std::string side = name.substr(0, 3);
-    std::string finger_name = name.substr(3, 2);
-    std::transform(finger_name.begin(), finger_name.end(), finger_name.begin(), [](unsigned char c)
-    {
-      return std::tolower(c);
-    });
-    // TODO: filter out thumb and wrist
-    int joint_index = std::atoi(name.substr(6, 1).c_str()) - 1;
-    if (joint_index >= 0 && joint_index <= 4)
-    {
-      joint_positions[side + finger_name + joint_names[joint_index]] = position;
-    }
+    return;
+  }
+  std::string finger_name = name.substr(3, 2);
+  if (include_fingers.find(finger_name) == include_fingers.end())
+  {
+    return;
+  }
+  std::transform(finger_name.begin(), finger_name.end(), finger_name.begin(), [](unsigned char c)
+  {
+    return std::tolower(c);
+  });
+  std::string side = name.substr(0, 3);
+  int joint_index = std::atoi(name.substr(6, 1).c_str());
+  if (joint_index > 0 && joint_index <= 4)
+  {
+    joint_positions[side + finger_name + joint_names[joint_index]] = position;
   }
 }
 

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -117,7 +117,7 @@ void UnderactuationErrorReporter::update_joint_position(
   std::transform(finger_name.begin(), finger_name.end(), finger_name.begin(), [](unsigned char c)
   {
     return std::tolower(c);
-  });
+  });  // NOLINT Our lint doesn't seem to support lambdas
   if (include_fingers_.find(finger_name) == include_fingers_.end())
   {
     return;

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -117,8 +117,7 @@ void UnderactuationErrorReporter::update_joint_position(
   std::transform(finger_name.begin(), finger_name.end(), finger_name.begin(), [](unsigned char c)
   {
     return std::tolower(c);
-  }
-  );
+  });
   if (include_fingers_.find(finger_name) == include_fingers_.end())
   {
     return;
@@ -143,7 +142,8 @@ void UnderactuationErrorReporter::joints_callback(const sensor_msgs::JointStateC
   publish_error();
 }
 
-void UnderactuationErrorReporter::trajectory_callback(const trajectory_msgs::JointTrajectory& msg) {
+void UnderactuationErrorReporter::trajectory_callback(const trajectory_msgs::JointTrajectory& msg)
+{
   for (int i = 0; i < msg.joint_names.size(); i++)
   {
     if (msg.points.size() > 0)

--- a/sr_error_reporter/src/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.hpp
@@ -7,6 +7,7 @@
 #define SR_INTERFACE_SR_ERROR_REPORTER_SRC_UNDERACTUATIONERRORREPORTER_HPP_
 
 #include <map>
+#include <set>
 #include <string>
 #include <vector>
 
@@ -35,6 +36,14 @@ class UnderactuationErrorReporter
    * MoveIt link name to radians. From /[lh|rh]_trajectory_controller/command topic.
    */
   std::map<std::string, double> desired_joint_angles;
+
+  std::set<std::string> include_fingers =
+  {
+    "FF",
+    "MF",
+    "RF",
+    "LF"
+  };
 
   std::vector<std::string> joint_names =
   {

--- a/sr_error_reporter/src/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.hpp
@@ -44,12 +44,27 @@ class UnderactuationErrorReporter
 
   std::set<std::string> sides_;
 
-  std::set<std::string> include_fingers_ =
+  std::map<std::string, std::string> include_fingers_ =
   {
-    "ff",
-    "mf",
-    "rf",
-    "lf"
+    {
+      "ff",
+      "first_finger"
+    }
+    ,
+    {
+      "mf",
+      "middle_finger"
+    }
+    ,
+    {
+      "rf",
+      "ring_finger"
+    }
+    ,
+    {
+      "lf",
+      "little_finger"
+    }
   };
 
   std::vector<std::string> joint_names_ =

--- a/sr_error_reporter/src/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.hpp
@@ -1,0 +1,57 @@
+/*
+* Copyright (C) 2021 Shadow Robot Company Ltd - All Rights Reserved. Proprietary and Confidential.
+* Unauthorized copying of the content in this file, via any medium is strictly prohibited.
+*/
+
+#ifndef SR_INTERFACE_SR_ERROR_REPORTER_SRC_UNDERACTUATIONERRORREPORTER_HPP_
+#define SR_INTERFACE_SR_ERROR_REPORTER_SRC_UNDERACTUATIONERRORREPORTER_HPP_
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include <moveit/robot_model_loader/robot_model_loader.h>
+#include <moveit/robot_model/robot_model.h>
+#include <moveit/robot_state/robot_state.h>
+#include <ros/ros.h>
+#include <sensor_msgs/JointState.h>
+#include <trajectory_msgs/JointTrajectory.h>
+
+class UnderactuationErrorReporter
+{
+ public:
+  explicit UnderactuationErrorReporter(ros::NodeHandle& node_handle);
+ private:
+  const ros::NodeHandle& node_handle;
+  robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
+  ros::Subscriber joints_subsriber, trajectory_subsriber_left, trajectory_subsriber_right;
+
+  /**
+   * MoveIt link name to radians. From /joint_states topic.
+   */
+  std::map<std::string, double> actual_joint_angles;
+
+  /**
+   * MoveIt link name to radians. From /[lh|rh]_trajectory_controller/command topic.
+   */
+  std::map<std::string, double> desired_joint_angles;
+
+  std::vector<std::string> joint_names =
+  {
+    "tip",
+    "distal",
+    "middle",
+    "proximal",
+    "knuckle"
+  };
+
+  void publish_error();
+  void update_joint_position(
+    std::map<std::string, double>& joint_positions,
+    std::string name,
+    double position);
+  void joints_callback(const sensor_msgs::JointStateConstPtr& msg);
+  void trajectory_callback(const trajectory_msgs::JointTrajectory& msg);
+};
+
+#endif  // SR_INTERFACE_SR_ERROR_REPORTER_SRC_UNDERACTUATIONERRORREPORTER_HPP_

--- a/sr_error_reporter/src/UnderactuationErrorReporter.hpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.hpp
@@ -24,10 +24,11 @@ class UnderactuationErrorReporter
  public:
   explicit UnderactuationErrorReporter(ros::NodeHandle& node_handle);
  private:
-  const ros::NodeHandle& node_handle_;
+  ros::NodeHandle& node_handle_;
   robot_model_loader::RobotModelLoaderPtr robot_model_loader_;
   moveit::core::RobotStatePtr robot_state_;
   ros::Subscriber joints_subsriber_, trajectory_subsriber_left_, trajectory_subsriber_right_;
+  std::map<std::string, ros::Publisher> error_publishers_;
 
   /**
    * MoveIt link name to radians. From /joint_states topic.
@@ -75,6 +76,8 @@ class UnderactuationErrorReporter
     "proximal",
     "knuckle"
   };
+
+  void add_side(std::string side);
 
   void update_kinematic_model(
     std::map<std::string, double>& joint_positions,

--- a/sr_error_reporter/src/error_reporter.cpp
+++ b/sr_error_reporter/src/error_reporter.cpp
@@ -1,10 +1,21 @@
 /*
-* Copyright (C) 2021 Shadow Robot Company Ltd - All Rights Reserved. Proprietary and Confidential.
-* Unauthorized copying of the content in this file, via any medium is strictly prohibited.
+* Copyright 2021 Shadow Robot Company Ltd.
+*
+* This program is free software: you can redistribute it and/or modify it
+* under the terms of the GNU General Public License as published by the Free
+* Software Foundation version 2 of the License.
+*
+* This program is distributed in the hope that it will be useful, but WITHOUT
+* ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+* FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for
+* more details.
+*
+* You should have received a copy of the GNU General Public License along
+* with this program. If not, see <http://www.gnu.org/licenses/>.
 */
 
 #include <ros/ros.h>
-#include "UnderactuationErrorReporter.hpp"
+#include "sr_error_reporter/UnderactuationErrorReporter.hpp"
 
 int main(int argc, char **argv)
 {

--- a/sr_error_reporter/src/error_reporter.cpp
+++ b/sr_error_reporter/src/error_reporter.cpp
@@ -1,0 +1,16 @@
+/*
+* Copyright (C) 2021 Shadow Robot Company Ltd - All Rights Reserved. Proprietary and Confidential.
+* Unauthorized copying of the content in this file, via any medium is strictly prohibited.
+*/
+
+#include <ros/ros.h>
+#include "UnderactuationErrorReporter.hpp"
+
+int main(int argc, char **argv)
+{
+  ros::init(argc, argv, "error_reporter");
+  ros::NodeHandle node_handle;
+  UnderactuationErrorReporter underactuation_error_reporter(node_handle);
+  ros::spin();
+  return 0;
+}

--- a/sr_robot_launch/launch/sr_ur_arm_hand.launch
+++ b/sr_robot_launch/launch/sr_ur_arm_hand.launch
@@ -207,4 +207,7 @@
     <include file="$(find sr_multi_moveit_config)/launch/default_warehouse_db.launch"/>
   </group>
 
+  <!-- Publish underactuation error -->
+  <node name="error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
+
 </launch>

--- a/sr_robot_launch/launch/sr_ur_arms_hands.launch
+++ b/sr_robot_launch/launch/sr_ur_arms_hands.launch
@@ -211,4 +211,8 @@
       </include>
       <include file="$(find sr_multi_moveit_config)/launch/default_warehouse_db.launch"/>
   </group>
+
+  <!-- Publish underactuation error -->
+  <node name="error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
+
 </launch>

--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -144,4 +144,7 @@
     <include file="$(find sr_moveit_hand_config)/launch/default_warehouse_db.launch"/>
   </group>
 
+   <!-- Publish underactuation error -->
+  <node name="error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
+
 </launch>

--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -144,7 +144,7 @@
     <include file="$(find sr_moveit_hand_config)/launch/default_warehouse_db.launch"/>
   </group>
 
-   <!-- Publish underactuation error -->
+  <!-- Publish underactuation error -->
   <node name="error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
 
 </launch>


### PR DESCRIPTION
## Proposed changes

Calculate and Publish underactuation error.

The following new topics are added:
* /underactuation_error/rh_fftip
* /underactuation_error/rh_lftip
* /underactuation_error/rh_mftip
* /underactuation_error/rh_rftip

Example of new message:
```
header: 
  seq: 2359
  stamp: 
    secs: 32
    nsecs:  39000000
  frame_id: ''
error: 0.0123959742486
```

New node is included in launch files `srhand.launch`, `sr_ur_arms_hand.launch` and `sr_ur_arms_hands.launch` or can be started manualy by running:
```
rosrun sr_error_reporter error_reporter
```

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
