### PR TITLE
UnderactuationErrorReporter needs both robot_description and robot_description_semantic

### DIFF
--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -33,6 +33,11 @@ UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_h
   trajectory_subscriber_right_ = node_handle.subscribe("/rh_trajectory_controller/state", 1,
     &UnderactuationErrorReporter::trajectory_callback_right, this, ros::TransportHints().tcpNoDelay());
 
+  if (!wait_for_param(node_handle, "robot_description"))
+  {
+    ROS_ERROR("UnderactuationErrorReporter did't find robot_description on parameter server");
+  }
+
   if (wait_for_param(node_handle, "robot_description_semantic"))
   {
     robot_model_loader_.reset(new robot_model_loader::RobotModelLoader("robot_description"));


### PR DESCRIPTION
## Proposed changes

UnderactuationErrorReporter needs both robot_description and robot_description_semantic.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
