### PR TITLE
SRC-6177 Fix little finger error reporting

### DIFF
--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -83,7 +83,16 @@ void UnderactuationErrorReporter::update_kinematic_model(
     {
       continue;
     }
-    std::vector<double> positions = {0, 0, j2->second, j1->second};
+    // Set all joint angles to 0
+    std::vector<double> positions = {0, 0};
+    if (finger.first == "lf")
+    {
+      // Little finger has 5 joints instead of 4
+      positions.push_back(0);
+    }
+    // except for underactuated joins which we want to measure
+    positions.push_back(j2->second);
+    positions.push_back(j1->second);
     robot_state_->setJointGroupPositions(side + finger.second, positions);
 
     std::string link_name = side + finger.first + "tip";


### PR DESCRIPTION
## Proposed changes

`error_reporting` node was failing with an error:
```
error_reporter: /opt/ros/noetic/include/moveit/robot_state/robot_state.h:619: void moveit::core::RobotState::setJointGroupPositions(const string&, const std::vector<double, std::allocator<double> >&): Assertion `gstate.size() == jmg->getVariableCount()' failed.
```
because code was assumed that all fingers except thumb has 4 joints. In this pull request code was corrected to assume that little finger has 5 joints.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
