### PR TITLE
Load hand trajectory controller for hand in sim use case

### DIFF
--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -106,6 +106,7 @@
     </node>
     <!-- Controller -->
     <group if="$(arg hand_ctrl)">
+      <rosparam file="$(find sr_robot_launch)/config/$(arg hand_id)_trajectory_controller.yaml" command="load"/>
       <node name="$(arg hand_id)_controller_spawner" pkg="sr_utilities" type="controller_spawner.py" output="screen">
         <param name="controller_group" value="$(arg hand_controller_group)"/>
       </node>


### PR DESCRIPTION
## Proposed changes

When using gazebo we need to load the trajectory controller in the right namespace. When a refactoring was done, this was not loaded for the hand only use case. this PR fixes it.

## Checklist

If the task is applicable to this pull request (see applicability criteria in brackets), make sure it is completed before checking the corresponding box. Otherwise, tick the box right away. Make sure that **ALL** boxes are checked **BEFORE** the PR is merged.

- [x] Manually tested that added code works as intended (if any functional/runnable code is added).
- [x] Added automated tests (if a new class is added (Python or C++), interface of that class must be unit tested).
- [x] Tested on real hardware (if the changed or added code is used with the real hardware).
- [x] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc.)
