### PR TITLE
Removing external control option for sim

### DIFF
--- a/sr_robot_launch/launch/sr_bimanual.launch
+++ b/sr_robot_launch/launch/sr_bimanual.launch
@@ -36,7 +36,7 @@
   <arg name="hand_x_separation" default="-0.4"/>
 
   <!-- SIMULATED ROBOTS -->
-  <group if="$(eval sim and not external_control_loop)">
+  <group if="$(arg sim)">
     <include file="$(find sr_robot_launch)/launch/sr_bimanual_simulation_control_loop.launch">
       <arg name="debug" value="$(arg debug)"/>
       <arg name="robot_state_pub_frequency" value="$(arg robot_state_pub_frequency)"/>

--- a/sr_robot_launch/launch/sr_ur_arm_hand.launch
+++ b/sr_robot_launch/launch/sr_ur_arm_hand.launch
@@ -74,7 +74,7 @@
   <!-- home_angles must be input at the launch -->
   <arg name="home_angles" default=""/>
 
-  <group if="$(eval sim and not external_control_loop)">
+  <group if="$(arg sim)">
     <include file="$(find sr_robot_launch)/launch/sr_simulation_control_loop.launch">
       <arg name="debug" value="$(arg debug)"/>
       <arg name="scene" value="$(arg scene)"/>

--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -40,7 +40,7 @@
   <!-- Set to hand_e, hand_e_plus or hand_lite or hand_extra_lite -->
   <arg name="hand_type" default="hand_e"/>
 
-  <group if="$(eval sim and not external_control_loop)">
+  <group if="$(arg sim)">
     <include file="$(find sr_robot_launch)/launch/sr_simulation_control_loop.launch">
       <arg name="debug" value="$(arg debug)"/>
       <arg name="robot_state_pub_frequency" value="$(arg robot_state_pub_frequency)"/>


### PR DESCRIPTION
## Proposed changes

Removing option for running external control loop in sim - not useful and the moment and breaks aurora.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added automated tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
