### PR TITLE
Check if goal has empty commands and do not send it if so on robot commander

### DIFF
--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -849,8 +849,9 @@ class SrRobotCommander(object):
     def _call_action(self, goals):
         for client in self._clients:
             self._action_running[client] = True
-            self._clients[client].send_goal(
-                goals[client], lambda terminal_state, result: self._action_done_cb(client, terminal_state, result))
+            if goals[client].trajectory.joint_names:
+                self._clients[client].send_goal(
+                    goals[client], lambda terminal_state, result: self._action_done_cb(client, terminal_state, result))
 
     def run_joint_trajectory_unsafe(self, joint_trajectory, wait=True):
         """


### PR DESCRIPTION
## Proposed changes

The aim of this PR is to fix this bug:

![image](https://user-images.githubusercontent.com/62122095/159002074-ddaf1997-9b60-4a95-967e-b58bf5fb5429.png)

This error is caused by sending trajectory goals with empty joint_names to the trajectory controllers. The error is triggered [here.](https://github.com/ros-controls/ros_controllers/blob/9af3234659b5c7dee3444a4d4a496f434868098e/joint_trajectory_controller/include/joint_trajectory_controller/joint_trajectory_controller_impl.h#L594-L601) It seems that since joint_names is empty, there is not any match with all the joints of the controller. This solution checks on the  robot commander if the goal does not have empty joint_names, and if it is not empty, it sends the goal.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
