### PR TITLE
Adding "first finger point" to named hand states

### DIFF
--- a/sr_moveit_hand_config/config/shadowhands_prefix.srdf.xacro
+++ b/sr_moveit_hand_config/config/shadowhands_prefix.srdf.xacro
@@ -285,6 +285,25 @@
       </xacro:if>
     </xacro:unless>
   </group_state>
+  <group_state name="first_finger_point" group="$(arg prefix)fingers">
+    <xacro:if value="$(arg th)">
+        <xacro:thumb_state_pack  prefix="$(arg prefix)" is_biotac="$(arg is_biotac)" />
+    </xacro:if>
+    <xacro:if value="$(arg ff)">
+        <xacro:finger_state_open  prefix="$(arg prefix)" joint_prefix="FF" lf="0" />
+    </xacro:if>
+    <xacro:if value="$(arg mf)">
+        <xacro:finger_state_pack  prefix="$(arg prefix)" joint_prefix="MF" lf="0" is_biotac="$(arg is_biotac)"/>
+    </xacro:if>
+    <xacro:if value="$(arg rf)">
+        <xacro:finger_state_pack  prefix="$(arg prefix)" joint_prefix="RF" lf="0" is_biotac="$(arg is_biotac)"/>
+    </xacro:if>
+    <xacro:unless value="$(arg is_lite)">
+      <xacro:if value="$(arg lf)">
+          <xacro:finger_state_pack  prefix="$(arg prefix)" joint_prefix="LF" lf="1" is_biotac="$(arg is_biotac)"/>
+      </xacro:if>
+    </xacro:unless>
+  </group_state>
 
   <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
 


### PR DESCRIPTION
## Proposed changes

Adding "first finger point" to named hand states, for use as an sr_fingertip_hand_teleop static grasp (gesture) mode.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
