### PR TITLE
SRDF generator now loads multi-robot move group states from yaml

### DIFF
--- a/sr_moveit_hand_config/config/shadowhand.srdf.xacro
+++ b/sr_moveit_hand_config/config/shadowhand.srdf.xacro
@@ -112,6 +112,42 @@
       <joint name="${prefix}THJ5" value="0.19" />
     </xacro:if>
   </xacro:macro>
+  <xacro:macro name="finger_state_relaxed" params="prefix joint_prefix">
+    <xacro:if value="${joint_prefix == 'FF'}">
+      <joint name="${prefix}${joint_prefix}J1" value="0.0128" />
+      <joint name="${prefix}${joint_prefix}J2" value="0.8508" />
+      <joint name="${prefix}${joint_prefix}J3" value="0.0156" />
+      <joint name="${prefix}${joint_prefix}J4" value="-0.05" />
+    </xacro:if>
+    <xacro:if value="${joint_prefix == 'MF'}">
+      <joint name="${prefix}${joint_prefix}J1" value="0.0246" />
+      <joint name="${prefix}${joint_prefix}J2" value="0.7201" />
+      <joint name="${prefix}${joint_prefix}J3" value="0.1918" />
+      <joint name="${prefix}${joint_prefix}J4" value="-0.0160" />
+    </xacro:if>
+    <xacro:if value="${joint_prefix == 'RF'}">
+      <joint name="${prefix}${joint_prefix}J1" value="0.0189" />
+      <joint name="${prefix}${joint_prefix}J2" value="0.5994" />
+      <joint name="${prefix}${joint_prefix}J3" value="0.4371" />
+      <joint name="${prefix}${joint_prefix}J4" value="-0.0297" />
+    </xacro:if>
+    <xacro:if value="${joint_prefix == 'LF'}">
+      <joint name="${prefix}${joint_prefix}J1" value="0.0093" />
+      <joint name="${prefix}${joint_prefix}J2" value="0.7751" />
+      <joint name="${prefix}${joint_prefix}J3" value="0.0861" />
+      <joint name="${prefix}${joint_prefix}J4" value="-0.2209" />
+      <joint name="${prefix}${joint_prefix}J5" value="0.3325" /> 
+    </xacro:if> 
+  </xacro:macro>
+  <xacro:macro name="thumb_state_relaxed" params="prefix">
+    <joint name="${prefix}THJ1" value="0.0837" />
+    <joint name="${prefix}THJ2" value="0.2629" />
+    <xacro:unless value="$(arg is_lite)">
+      <joint name="${prefix}THJ3" value="-0.0944" />
+    </xacro:unless>
+    <joint name="${prefix}THJ4" value="0.5838" />
+    <joint name="${prefix}THJ5" value="0.1794" />
+  </xacro:macro>
   <xacro:macro name="finger_thumb_state_open" params="prefix finger_name joint_prefix lf is_lite">
    <group_state name="${finger_name}_thumb_open" group="${prefix}${finger_name}_thumb">
       <joint name="${prefix}${joint_prefix}J1" value="0" />

--- a/sr_moveit_hand_config/config/shadowhands_prefix.srdf.xacro
+++ b/sr_moveit_hand_config/config/shadowhands_prefix.srdf.xacro
@@ -304,6 +304,46 @@
       </xacro:if>
     </xacro:unless>
   </group_state>
+  <group_state name="relaxed" group="$(arg prefix)fingers">
+    <xacro:if value="$(arg th)">
+        <xacro:thumb_state_relaxed  prefix="$(arg prefix)"/>
+    </xacro:if>
+    <xacro:if value="$(arg ff)">
+        <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="FF"/>
+    </xacro:if>
+    <xacro:if value="$(arg mf)">
+        <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="MF"/>
+    </xacro:if>
+    <xacro:if value="$(arg rf)">
+        <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="RF"/>
+    </xacro:if>
+    <xacro:unless value="$(arg is_lite)">
+      <xacro:if value="$(arg lf)">
+          <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="LF"/>
+      </xacro:if>
+    </xacro:unless>
+  </group_state>
+  <group_state name="relaxed" group="$(arg hand_name)">
+    <xacro:if value="$(arg th)">
+        <xacro:thumb_state_relaxed  prefix="$(arg prefix)"/>
+    </xacro:if>
+    <xacro:if value="$(arg ff)">
+        <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="FF"/>
+    </xacro:if>
+    <xacro:if value="$(arg mf)">
+        <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="MF"/>
+    </xacro:if>
+    <xacro:if value="$(arg rf)">
+        <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="RF"/>
+    </xacro:if>
+    <xacro:unless value="$(arg is_lite)">
+      <xacro:if value="$(arg lf)">
+          <xacro:finger_state_relaxed  prefix="$(arg prefix)" joint_prefix="LF"/>
+      </xacro:if>
+      <joint name="$(arg prefix)WRJ1" value="0" />
+      <joint name="$(arg prefix)WRJ2" value="0" />
+    </xacro:unless>
+  </group_state>
 
   <!--END EFFECTOR: Purpose: Represent information about an end effector.-->
 

--- a/sr_multi_moveit/sr_multi_moveit_config/README.md
+++ b/sr_multi_moveit/sr_multi_moveit_config/README.md
@@ -6,4 +6,4 @@ Configuration of multiple robots running as a combined robot.
 
 At run time, [generate_robot_srdf.py](scripts/generate_robot_srdf.py) parses individual robot (UR arms, Shadow Hands) U/SRDFs and creates move groups that include links from multiple robot definitions. It also loads and parses a configuration file ([multi_robot_move_group_states.yaml](config/multi_robot_move_group_states.yaml) by default) that defines named joint states for these combined robot move groups. These combined move group states can inherit joint angles from states defined in individual robot U/SRDFs.
 
-The resulting combined robot description SRDF is loaded onto the ROS parameter server for use by various nodes, at `/robot_description`, and saved to [config/generated_robot.srdf](config/generated_robot.srdf) for introspection.
+The resulting combined robot description SRDF is loaded onto the ROS parameter server for use by various nodes, at `/robot_description_semantic`, and saved to [config/generated_robot.srdf](config/generated_robot.srdf) for introspection.

--- a/sr_multi_moveit/sr_multi_moveit_config/README.md
+++ b/sr_multi_moveit/sr_multi_moveit_config/README.md
@@ -1,7 +1,9 @@
 # sr_multi_moveit_config
 
-Configuration of multiple-robots running as a combined robot.
+Configuration of multiple robots running as a combined robot.
 
 ## Multi-Robot Move Groups and States
 
 At run time, [generate_robot_srdf.py](scripts/generate_robot_srdf.py) parses individual robot (UR arms, Shadow Hands) U/SRDFs and creates move groups that include links from multiple robot definitions. It also loads and parses a configuration file ([multi_robot_move_group_states.yaml](config/multi_robot_move_group_states.yaml) by default) that defines named joint states for these combined robot move groups. These combined move group states can inherit joint angles from states defined in individual robot U/SRDFs.
+
+The resulting combined robot description SRDF is loaded onto the ROS parameter server for use by various nodes, at `/robot_description`, and saved to [config/generated_robot.srdf](config/generated_robot.srdf) for introspection.

--- a/sr_multi_moveit/sr_multi_moveit_config/README.md
+++ b/sr_multi_moveit/sr_multi_moveit_config/README.md
@@ -1,0 +1,7 @@
+# sr_multi_moveit_config
+
+Configuration of multiple-robots running as a combined robot.
+
+## Multi-Robot Move Groups and States
+
+At run time, [generate_robot_srdf.py](scripts/generate_robot_srdf.py) parses individual robot (UR arms, Shadow Hands) U/SRDFs and creates move groups that include links from multiple robot definitions. It also loads and parses a configuration file ([multi_robot_move_group_states.yaml](config/multi_robot_move_group_states.yaml) by default) that defines named joint states for these combined robot move groups. These combined move group states can inherit joint angles from states defined in individual robot U/SRDFs.

--- a/sr_multi_moveit/sr_multi_moveit_config/config/move_group_states.yaml
+++ b/sr_multi_moveit/sr_multi_moveit_config/config/move_group_states.yaml
@@ -1,0 +1,69 @@
+left_arm:
+  la_start:
+    joint_angles:
+      la_elbow_joint: -2.0
+      la_shoulder_lift_joint: -1.89
+      la_shoulder_pan_joint: 0.0
+      la_wrist_1_joint: -2.4
+      la_wrist_2_joint: -1.5708
+      la_wrist_3_joint: 3.1416
+left_arm_and_wrist:
+  la_start:
+    inherit_from:
+      - move_group: left_arm
+        move_group_state: la_start
+    joint_angles:
+      lh_WRJ1: 0.0
+      lh_WRJ2: 0.0
+left_arm_and_hand:
+  la_start:
+    inherit_from:
+      - move_group: left_arm_and_wrist
+        move_group_state: la_start
+      - move_group: left_hand
+        move_group_state: relaxed
+right_arm:
+  ra_start:
+    joint_angles:
+      ra_elbow_joint: 2.0
+      ra_shoulder_lift_joint: -1.25
+      ra_shoulder_pan_joint: 0.0
+      ra_wrist_1_joint: -0.733
+      ra_wrist_2_joint: 1.5708
+      ra_wrist_3_joint: -3.1416
+right_arm_and_wrist:
+  ra_start:
+    inherit_from:
+      - move_group: right_arm
+        move_group_state: ra_start
+    joint_angles:
+      rh_WRJ1: 0.0
+      rh_WRJ2: 0.0
+right_arm_and_hand:
+  ra_start:
+    inherit_from:
+      - move_group: right_arm_and_wrist
+        move_group_state: ra_start
+      - move_group: right_hand
+        move_group_state: relaxed
+two_arms:
+  start:
+    inherit_from:
+      - move_group: right_arm
+        move_group_state: ra_start
+      - move_group: left_arm
+        move_group_state: la_start
+two_arms_and_wrists:
+  start:
+    inherit_from:
+      - move_group: right_arm_and_wrist
+        move_group_state: ra_start
+      - move_group: left_arm_and_wrist
+        move_group_state: la_start
+two_arms_and_hands:
+  start:
+    inherit_from:
+      - move_group: right_arm_and_hand
+        move_group_state: ra_start
+      - move_group: left_arm_and_hand
+        move_group_state: la_start

--- a/sr_multi_moveit/sr_multi_moveit_config/config/multi_robot_move_group_states.yaml
+++ b/sr_multi_moveit/sr_multi_moveit_config/config/multi_robot_move_group_states.yaml
@@ -1,6 +1,8 @@
-left_arm:
-  la_start:
-    joint_angles:
+# This file is used to define move group states that span multiple robots, and therefore can't be defined in the
+# individual robot SRDFs. It is parsed in generate_robot_srdf.py.
+left_arm:  # Must be an existing move group; ignored if not.
+  la_start:  # The name of the new move group state that will be created.
+    joint_angles:  # A dictionary of joint names and angles (in radians) that define the new move group state.
       la_elbow_joint: -2.0
       la_shoulder_lift_joint: -1.89
       la_shoulder_pan_joint: 0.0
@@ -9,19 +11,19 @@ left_arm:
       la_wrist_3_joint: 3.1416
 left_arm_and_wrist:
   la_start:
-    inherit_from:
+    inherit_from:  # States can inherit from other states, which must be defined either in this file or in a robot SRDF.
       - move_group: left_arm
-        move_group_state: la_start
+        move_group_state: la_start  # Defined in this file.
     joint_angles:
       lh_WRJ1: 0.0
       lh_WRJ2: 0.0
 left_arm_and_hand:
   la_start:
-    inherit_from:
+    inherit_from:  # States can inherit from multiple other states.
       - move_group: left_arm_and_wrist
         move_group_state: la_start
       - move_group: left_hand
-        move_group_state: relaxed
+        move_group_state: relaxed  # Defined in the robot SRDF.
 right_arm:
   ra_start:
     joint_angles:

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/planning_context.launch
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/planning_context.launch
@@ -18,7 +18,7 @@
   <arg name="robot_config_file" default=""/>
 
   <!-- The name of the config file to load saved move groups states from -->
-  <arg name="move_group_states_file" default="$(find sr_multi_moveit_config)/config/move_group_states.yaml"/>
+  <arg name="move_group_states_file" default="$(find sr_multi_moveit_config)/config/multi_robot_move_group_states.yaml"/>
 
   <!-- The semantic description that corresponds to the URDF -->
   <node name="generate_robot_srdf" pkg="sr_multi_moveit_config" type="generate_robot_srdf.py" respawn="false" output="screen" args="$(arg robot_config_file) $(arg move_group_states_file)" />

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/planning_context.launch
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/planning_context.launch
@@ -17,8 +17,11 @@
   <!-- The name of the robot config file to load -->
   <arg name="robot_config_file" default=""/>
 
+  <!-- The name of the config file to load saved move groups states from -->
+  <arg name="move_group_states_file" default="$(find sr_multi_moveit_config)/config/move_group_states.yaml"/>
+
   <!-- The semantic description that corresponds to the URDF -->
-  <node name="generate_robot_srdf" pkg="sr_multi_moveit_config" type="generate_robot_srdf.py" respawn="false" output="screen" args="$(arg robot_config_file)" />
+  <node name="generate_robot_srdf" pkg="sr_multi_moveit_config" type="generate_robot_srdf.py" respawn="false" output="screen" args="$(arg robot_config_file) $(arg move_group_states_file)" />
 
   <!-- Load updated joint limits (override information from URDF) -->
   <group ns="$(arg robot_description_name)_planning">

--- a/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
+++ b/sr_multi_moveit/sr_multi_moveit_config/scripts/generate_robot_srdf.py
@@ -35,6 +35,7 @@ from __future__ import absolute_import
 import sys
 import os
 from xml.dom.minidom import parse
+import re
 import rospkg
 import xml
 import yaml
@@ -166,6 +167,16 @@ class SRDFRobotGenerator(object):
         if description_file is None and len(sys.argv) > 1:
             description_file = sys.argv[1]
 
+        # If specified, load the combined robot move group joint states from the config file
+        self._combined_move_group_states = {}
+        if len(sys.argv) > 2:
+            try:
+                with open(sys.argv[2], "r") as stream:
+                    self._combined_move_group_states = yaml.safe_load(stream)
+            except FileNotFoundError:
+                rospy.logwarn(f'Could not open the specified move group saved states definition file: '
+                              f'"{sys.argv[2]}". No move group saved states loaded.')
+
         self._save_files = rospy.get_param('~save_files', False)
         self._path_to_save_files = rospy.get_param('~path_to_save_files', "/tmp/")
         self._file_name = rospy.get_param('~file_name', "generated_robot")
@@ -204,7 +215,6 @@ class SRDFRobotGenerator(object):
             # Add groups and group states
             if manipulator.has_arm:
                 self.parse_arm_groups(manipulator_id, manipulator)
-                self.add_more_arm_groups(manipulator)
             if manipulator.has_hand:
                 self.parse_hand_groups(manipulator_id, manipulator)
 
@@ -255,6 +265,9 @@ class SRDFRobotGenerator(object):
             if manipulator.has_hand:
                 self.parse_hand_collisions(manipulator_id, manipulator)
 
+        # Add the config-file-defined multi-robot move group states
+        self.add_move_group_states()
+
         # Finish and close file
         self.new_robot_srdf.write('</robot>\n')
         self.new_robot_srdf.close()
@@ -285,7 +298,7 @@ class SRDFRobotGenerator(object):
 
     def start_new_srdf(self, file_name):
         # Generate new robot srdf with arm information
-        self.new_robot_srdf = open(self.package_path + "/config/" + file_name, 'w')
+        self.new_robot_srdf = open(self.package_path + "/config/" + file_name, 'w+')
 
         self.new_robot_srdf.write('<?xml version="1.0" ?>\n')
         banner = ["This does not replace URDF, and is not an extension of URDF.\n" +
@@ -394,50 +407,94 @@ class SRDFRobotGenerator(object):
             previous = elt
             elt = next_element(previous)
 
-    def add_more_arm_groups(self, manipulator):
-        new_group = xml.dom.minidom.Document().createElement('group_state')
-        new_group.setAttribute("group", manipulator.arm.internal_name)
-        new_group.setAttribute("name", manipulator.arm.prefix + "start")
-        if manipulator.side == "right":
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'elbow_joint" value="2.0"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'shoulder_lift_joint" value="-1.25"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'shoulder_pan_joint" value="0.0"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'wrist_1_joint" value="-0.733"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'wrist_2_joint" value="1.5708"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'wrist_3_joint" value="-3.1416"')
-            new_group.appendChild(joint)
-            new_group.writexml(self.new_robot_srdf, indent="  ", addindent="  ", newl="\n")
-        else:
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'elbow_joint" value="-2.0"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'shoulder_lift_joint" value="-1.89"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'shoulder_pan_joint" value="0.0"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'wrist_1_joint" value="-2.4"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'wrist_2_joint" value="-1.5708"')
-            new_group.appendChild(joint)
-            joint = xml.dom.minidom.Document().createElement(
-                'joint name="' + manipulator.arm.prefix + 'wrist_3_joint" value="3.1416"')
-            new_group.appendChild(joint)
-            new_group.writexml(self.new_robot_srdf, indent="  ", addindent="  ", newl="\n")
+    # Get move group states from an XML DOM, returning a dictionary of {move_group: {state: values}
+    @staticmethod
+    def parse_move_group_states(srdf_xml_dom, group_states={}):
+        for group_state_xml in srdf_xml_dom.getElementsByTagName("group_state"):
+            group = group_state_xml.getAttribute("group")
+            state_name = group_state_xml.getAttribute("name")
+            if group not in group_states:
+                group_states[group] = {}
+            group_states[group][state_name] = {}
+            for group_state_child in group_state_xml.childNodes:
+                if group_state_child.localName == "joint":
+                    group_states[group][state_name][group_state_child.getAttribute("name")] = \
+                        group_state_child.getAttribute("value")
+        return group_states
+
+    # Generate multi-robot move group states
+    def add_move_group_states(self):
+        # Check which move groups are in the generated SRDF
+        self.new_robot_srdf.seek(0)
+        move_group_names = list(set(re.findall(r'<group\s+.*name="([^"]*)"', self.new_robot_srdf.read())))
+        # Collect the move group states defined in the seperate robot SRDFs
+        self._original_move_group_states = {}
+        for hand_xml in self.hand_srdf_xmls:
+            SRDFRobotGenerator.parse_move_group_states(hand_xml, self._original_move_group_states)
+        for arm_xml in self.arm_srdf_xmls:
+            SRDFRobotGenerator.parse_move_group_states(arm_xml, self._original_move_group_states)
+        # Put the original move group states in the list of all move group states
+        self._move_group_states = deepcopy(self._original_move_group_states)
+        # Keep track of the combined move group states we are newly generating
+        self._new_move_group_states = {}
+        # For any existing move groups
+        for move_group_name in move_group_names:
+            # If there are combined move group states defined
+            if move_group_name in self._combined_move_group_states:
+                # For each combined move group state
+                for move_group_state_name in self._combined_move_group_states[move_group_name]:
+                    # If it has not already been defined
+                    if (move_group_name not in self._move_group_states or
+                            move_group_state_name not in self._move_group_states[move_group_name]):
+                        # Create the move group state, resolving any inherited values
+                        self.create_move_group_state(move_group_name, move_group_state_name)
+        # Write all of the newly generated move group states to the generated SRDF
+        for move_group_name, move_group_states in self._new_move_group_states.items():
+            for move_group_state_name, move_group_state in move_group_states.items():
+                new_group_state = xml.dom.minidom.Document().createElement('group_state')
+                new_group_state.setAttribute("group", move_group_name)
+                new_group_state.setAttribute("name", move_group_state_name)
+                for joint_name, joint_angle in move_group_state.items():
+                    new_group_state.appendChild(xml.dom.minidom.Document().createElement(
+                        f'joint name="{joint_name}" value="{joint_angle}"'))
+                new_group_state.writexml(self.new_robot_srdf, indent="  ", addindent="  ", newl="\n")
+
+    # Creates a new move group state, resolving any values inherited from other move groups
+    def create_move_group_state(self, group_name, group_state_name):
+        combined_move_group_state = self._combined_move_group_states[group_name][group_state_name]
+        if "joint_angles" not in combined_move_group_state:
+            combined_move_group_state["joint_angles"] = {}
+        # If the new move group state inherits from any others
+        if "inherit_from" in combined_move_group_state:
+            for ancestor in combined_move_group_state["inherit_from"]:
+                ancestor_group = ancestor["move_group"]
+                ancestor_group_state = ancestor["move_group_state"]
+                # If the ancestor group state is not defined yet
+                if (ancestor_group not in self._move_group_states or
+                        ancestor_group_state not in self._move_group_states[ancestor_group]):
+                    # If the ancestor group state is not even defined in the combined move group states
+                    if (ancestor_group not in self._combined_move_group_states or
+                            ancestor_group_state not in self._combined_move_group_states[ancestor_group]):
+                        rospy.logwarn(f'Unable to create move group "{group_name}" state "{group_state_name}", as it '
+                                      f'inherits from move group "{ancestor_group}" state "{ancestor_group_state}", '
+                                      f'which is not defined.')
+                        return False
+                    else:
+                        # Try to create the ancestor group state, return if failed
+                        if not self.create_move_group_state(ancestor_group, ancestor_group_state):
+                            return False
+                # The ancestor group state either already existed or has been created
+                ancestor_move_group_state = self._move_group_states[ancestor_group][ancestor_group_state]
+                for joint, value in ancestor_move_group_state.items():
+                    if joint not in combined_move_group_state["joint_angles"]:
+                        combined_move_group_state["joint_angles"][joint] = value
+        if group_name not in self._move_group_states:
+            self._move_group_states[group_name] = {}
+        self._move_group_states[group_name][group_state_name] = combined_move_group_state["joint_angles"]
+        if group_name not in self._new_move_group_states:
+            self._new_move_group_states[group_name] = {}
+        self._new_move_group_states[group_name][group_state_name] = combined_move_group_state["joint_angles"]
+        return True
 
     def add_bimanual_arm_groups(self, group_1, group_2, hands=True):
         new_group = xml.dom.minidom.Document().createElement('group')


### PR DESCRIPTION
## Proposed changes

SRDF generator now loads multi-robot move group states from a yaml file. These group states can reference each other or SRDF-defined groups. Adding "relaxed hand" states and including them in arm start states (only if hand move groups exist).

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [ ] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [x] Updated documentation (For changes to pre-existing features mentioned in the documentation).
