### PR TITLE
Updating robot states service and increasing demo sleep time

### DIFF
--- a/sr_demos/scripts/sr_demos/close.py
+++ b/sr_demos/scripts/sr_demos/close.py
@@ -32,7 +32,7 @@ from sr_robot_commander.sr_hand_commander import SrHandCommander
 
 if __name__ == "__main__":
 
-    rospy.init_node("close_hand", anonymous=True)
+    rospy.init_node("close_hand", anonymous=True, log_level=rospy.DEBUG)
 
     parser = argparse.ArgumentParser(description="Hand side")
     parser.add_argument("-s", "--side",
@@ -65,7 +65,8 @@ if __name__ == "__main__":
         },
         {
             'name': 'pack',
-            'interpolate_time': 3.0
+            'interpolate_time': 3.0,
+            'pause_time': 2
         }
     ]
 

--- a/sr_demos/scripts/sr_demos/close.py
+++ b/sr_demos/scripts/sr_demos/close.py
@@ -32,7 +32,7 @@ from sr_robot_commander.sr_hand_commander import SrHandCommander
 
 if __name__ == "__main__":
 
-    rospy.init_node("close_hand", anonymous=True, log_level=rospy.DEBUG)
+    rospy.init_node("close_hand", anonymous=True)
 
     parser = argparse.ArgumentParser(description="Hand side")
     parser.add_argument("-s", "--side",

--- a/sr_demos/scripts/sr_demos/demo.py
+++ b/sr_demos/scripts/sr_demos/demo.py
@@ -451,7 +451,7 @@ def complete_random_sequence(hand_commander, joint_states_config):
         random.randrange(joint_states_config['min_range'][f'{prefix}LFJ4'],
                          joint_states_config['rand_pos'][f'{prefix}RFJ4'])
     inter_time = 4.0 * random.random()
-    execute_command_check(hand_commander, joint_states_config, 'rand_pos', 0.0, inter_time)
+    execute_command_check(hand_commander, joint_states_config, 'rand_pos', 0.2, inter_time)
 
 
 def correct_joint_states_for_hand_type(joint_states_config, hand_type):

--- a/sr_demos/scripts/sr_demos/open.py
+++ b/sr_demos/scripts/sr_demos/open.py
@@ -34,7 +34,7 @@ from sr_robot_commander.sr_hand_commander import SrHandCommander
 
 if __name__ == "__main__":
 
-    rospy.init_node("open_hand", anonymous=True)
+    rospy.init_node("open_hand", anonymous=True, log_level=rospy.DEBUG)
 
     parser = argparse.ArgumentParser(description="Hand side")
     parser.add_argument("-s", "--side",

--- a/sr_demos/scripts/sr_demos/open.py
+++ b/sr_demos/scripts/sr_demos/open.py
@@ -34,7 +34,7 @@ from sr_robot_commander.sr_hand_commander import SrHandCommander
 
 if __name__ == "__main__":
 
-    rospy.init_node("open_hand", anonymous=True, log_level=rospy.DEBUG)
+    rospy.init_node("open_hand", anonymous=True)
 
     parser = argparse.ArgumentParser(description="Hand side")
     parser.add_argument("-s", "--side",

--- a/sr_robot_commander/src/sr_robot_commander/follow_warehouse_trajectory.py
+++ b/sr_robot_commander/src/sr_robot_commander/follow_warehouse_trajectory.py
@@ -63,13 +63,13 @@ class WarehousePlanner:
 
         rospy.sleep(4)
         rospy.loginfo("Waiting for warehouse services...")
-        rospy.wait_for_service('/list_robot_states')
+        rospy.wait_for_service('/list_robot_state')
         rospy.wait_for_service('/get_robot_state')
         rospy.wait_for_service('/has_robot_state')
 
         rospy.wait_for_service('/compute_fk')
         self._list_states = rospy.ServiceProxy(
-            '/list_robot_states', ListStates)
+            '/list_robot_state', ListStates)
         self._get_state = rospy.ServiceProxy(
             '/get_robot_state', GetState)
         self._has_state = rospy.ServiceProxy(

--- a/sr_robot_commander/src/sr_robot_commander/mock_state_services.py
+++ b/sr_robot_commander/src/sr_robot_commander/mock_state_services.py
@@ -62,6 +62,6 @@ if __name__ == "__main__":
     rospy.init_node('mock_services', anonymous=True)
     service_1 = rospy.Service('/get_robot_state', GetState, mock_get_state_callback)
     service_2 = rospy.Service('/has_robot_state', HasState, mock_has_state_callback)
-    service_3 = rospy.Service('/list_robot_states', ListState, mock_list_state_callback)
+    service_3 = rospy.Service('/list_robot_state', ListState, mock_list_state_callback)
     service_4 = rospy.Service('/save_robot_state', SaveState, mock_save_state_callback)
     rospy.spin()

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -529,7 +529,7 @@ class SrRobotCommander:
         """
         plan = RobotTrajectory()
         plan.joint_trajectory = joint_trajectory
-        return self.execute_plan(plan)
+        return self._move_group_commander.execute(plan)
 
     def make_named_trajectory(self, trajectory):
         """

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -462,7 +462,7 @@ class SrRobotCommander:
 
     def get_warehouse_names(self):
         try:
-            list_srv = rospy.ServiceProxy("list_robot_states", ListStates)
+            list_srv = rospy.ServiceProxy("list_robot_state", ListStates)
             return list_srv("", self._robot_name).states
         except rospy.ServiceException as exc:
             rospy.logwarn("Couldn't access warehouse: " + str(exc))
@@ -529,7 +529,7 @@ class SrRobotCommander:
         """
         plan = RobotTrajectory()
         plan.joint_trajectory = joint_trajectory
-        return self._move_group_commander.execute(plan)
+        return self.execute_plan(plan)
 
     def make_named_trajectory(self, trajectory):
         """

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_state_exporter.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_state_exporter.py
@@ -42,7 +42,7 @@ class SrRobotStateExporter:
             start_dictionary = {}
         self._get_state = rospy.ServiceProxy("/get_robot_state", GetState)
         self._has_state = rospy.ServiceProxy("/has_robot_state", HasState)
-        self._list_states = rospy.ServiceProxy("/list_robot_states", ListState)
+        self._list_states = rospy.ServiceProxy("/list_robot_state", ListState)
         self._save_state = rospy.ServiceProxy("/save_robot_state", SaveState)
         self._dictionary = deepcopy(start_dictionary)
 


### PR DESCRIPTION
## Proposed changes

Last year they changed the name of the robot state service from list_robot_states to list_robot_state https://github.com/ros-planning/moveit/blame/noetic-devel/moveit_ros/warehouse/warehouse/src/warehouse_services.cpp#L198 

Added a sleep to execute_command_check in complete_random_sequence in demo.py to prevent error of https://github.com/ros/actionlib/blob/noetic-devel/actionlib/src/actionlib/simple_action_client.py#L217  occurring.

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [ ] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
