### PR TITLE
Adding display of TF by default unenabled and RobotModel

### DIFF
--- a/sr_moveit_hand_config/launch/moveit.rviz
+++ b/sr_moveit_hand_config/launch/moveit.rviz
@@ -114,6 +114,22 @@ Visualization Manager:
         {}
       Update Interval: 0
       Value: false
+    - Class: rviz/RobotModel
+      Alpha: 1
+      Collision Enabled: false
+      Enabled: false
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: false
+      Visual Enabled: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/sr_moveit_hand_config/launch/moveit.rviz
+++ b/sr_moveit_hand_config/launch/moveit.rviz
@@ -99,6 +99,21 @@ Visualization Manager:
       Show Visual Aids: false
       Update Topic: /interactive_finger_control/update
       Value: false
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Alpha: 1
+      Marker Scale: 0.1
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/sr_moveit_hand_config/launch/moveit.rviz
+++ b/sr_moveit_hand_config/launch/moveit.rviz
@@ -105,7 +105,7 @@ Visualization Manager:
       Frames:
         All Enabled: true
       Marker Alpha: 1
-      Marker Scale: 0.1
+      Marker Scale: 0.15
       Name: TF
       Show Arrows: true
       Show Axes: true

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/moveit.rviz
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/moveit.rviz
@@ -333,7 +333,7 @@ Visualization Manager:
       Frames:
         All Enabled: true
       Marker Alpha: 1
-      Marker Scale: 0.15
+      Marker Scale: 0.3
       Name: TF
       Show Arrows: true
       Show Axes: true

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/moveit.rviz
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/moveit.rviz
@@ -327,6 +327,21 @@ Visualization Manager:
         {}
       Queue Size: 100
       Value: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Alpha: 1
+      Marker Scale: 0.15
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/moveit.rviz
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/moveit.rviz
@@ -342,6 +342,22 @@ Visualization Manager:
         {}
       Update Interval: 0
       Value: false
+    - Class: rviz/RobotModel
+      Alpha: 1
+      Collision Enabled: false
+      Enabled: false
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: false
+      Visual Enabled: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/moveit_hands.rviz
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/moveit_hands.rviz
@@ -883,6 +883,21 @@ Visualization Manager:
         {}
       Queue Size: 100
       Value: true
+    - Class: rviz/TF
+      Enabled: false
+      Frame Timeout: 15
+      Frames:
+        All Enabled: true
+      Marker Alpha: 1
+      Marker Scale: 0.15
+      Name: TF
+      Show Arrows: true
+      Show Axes: true
+      Show Names: true
+      Tree:
+        {}
+      Update Interval: 0
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48

--- a/sr_multi_moveit/sr_multi_moveit_config/launch/moveit_hands.rviz
+++ b/sr_multi_moveit/sr_multi_moveit_config/launch/moveit_hands.rviz
@@ -898,6 +898,22 @@ Visualization Manager:
         {}
       Update Interval: 0
       Value: false
+    - Class: rviz/RobotModel
+      Alpha: 1
+      Collision Enabled: false
+      Enabled: false
+      Links:
+        All Links Enabled: true
+        Expand Joint Details: false
+        Expand Link Details: false
+        Expand Tree: false
+        Link Tree Style: Links in Alphabetic Order
+      Name: RobotModel
+      Robot Description: robot_description
+      TF Prefix: ""
+      Update Interval: 0
+      Value: false
+      Visual Enabled: true
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48


### PR DESCRIPTION
## Proposed changes

Story: https://shadowrobot.atlassian.net/browse/SP-678

Added the **tf** (unenabled) by default to rviz configs in sr_moveit_hand_config and sr_multi_moveit.
The scale is **0.15** in sr_moveit_hand_config/launch/moveit.rviz and sr_multi_moveit/moveit_hands.rviz and **0.3** in sr_multi_moveit/moveit.rviz, becuase this one is likely to have an arm and it is better to see the tf's bigger.

This PR also adds the **RobotModel** unenabled as well.

Adding the tf visualization to rviz unenabled and with scale=0.15 by default to unimanual, bimanual and hand + arm.
![image](https://github.com/shadow-robot/sr_interface/assets/62122095/8c124126-461c-433a-a644-87323594b7d2)
![image](https://github.com/shadow-robot/sr_interface/assets/62122095/7066bedc-c5fa-456f-889b-886e5ad64e9f)
![image](https://github.com/shadow-robot/sr_interface/assets/62122095/6a058642-fdab-42b6-be1b-327bd2ce0171)


## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [x] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
