### PR TITLE
Make new palm flesh the default palm for Hands E and G (lite)

### DIFF
--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -39,11 +39,6 @@
 UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_handle)
   : node_handle_(node_handle)
 {
-  trajectory_subscriber_left_ = node_handle.subscribe("/lh_trajectory_controller/state", 1,
-    &UnderactuationErrorReporter::trajectory_callback_left, this, ros::TransportHints().tcpNoDelay());
-  trajectory_subscriber_right_ = node_handle.subscribe("/rh_trajectory_controller/state", 1,
-    &UnderactuationErrorReporter::trajectory_callback_right, this, ros::TransportHints().tcpNoDelay());
-
   if (!wait_for_param(node_handle, "robot_description"))
   {
     ROS_ERROR("UnderactuationErrorReporter did't find robot_description on parameter server");
@@ -58,6 +53,11 @@ UnderactuationErrorReporter::UnderactuationErrorReporter(ros::NodeHandle& node_h
   {
     ROS_ERROR("UnderactuationErrorReporter did't find robot_description_semantic on parameter server");
   }
+
+  trajectory_subscriber_left_ = node_handle.subscribe("/lh_trajectory_controller/state", 1,
+    &UnderactuationErrorReporter::trajectory_callback_left, this, ros::TransportHints().tcpNoDelay());
+  trajectory_subscriber_right_ = node_handle.subscribe("/rh_trajectory_controller/state", 1,
+    &UnderactuationErrorReporter::trajectory_callback_right, this, ros::TransportHints().tcpNoDelay());
 }
 
 ros::Publisher UnderactuationErrorReporter::get_or_create_publisher(

--- a/sr_error_reporter/src/UnderactuationErrorReporter.cpp
+++ b/sr_error_reporter/src/UnderactuationErrorReporter.cpp
@@ -1,6 +1,6 @@
 /*
 * Software License Agreement (BSD License)
-* Copyright © 2021-2023 belongs to Shadow Robot Company Ltd.
+* Copyright © 2021-2024 belongs to Shadow Robot Company Ltd.
 * All rights reserved.
 *
 * Redistribution and use in source and binary forms, with or without modification,

--- a/sr_multi_moveit/sr_multi_moveit_test/scripts/test_planners.py
+++ b/sr_multi_moveit/sr_multi_moveit_test/scripts/test_planners.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
-# Copyright © 2019, 2022-2023 belongs to Shadow Robot Company Ltd.
+# Copyright © 2019, 2022-2024 belongs to Shadow Robot Company Ltd.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/sr_multi_moveit/sr_multi_moveit_test/scripts/test_planners.py
+++ b/sr_multi_moveit/sr_multi_moveit_test/scripts/test_planners.py
@@ -267,8 +267,7 @@ class TestPlanners:
         wpose = waypoints[0]
         waypoints.append(copy.deepcopy(wpose))
 
-        (plan3, fraction) = self.group.compute_cartesian_path(
-            waypoints, 0.01, 0.0)
+        (plan3, fraction) = self.group.compute_cartesian_path(waypoints, 0.01)
         if not self._check_plan(plan3) and fraction > 0.8:
             self.fail_list.append("Failed: test_waypoints, " + self.planner)
         else:

--- a/sr_robot_commander/src/sr_robot_commander/follow_warehouse_trajectory.py
+++ b/sr_robot_commander/src/sr_robot_commander/follow_warehouse_trajectory.py
@@ -52,7 +52,6 @@ class WarehousePlanner:
         rospy.sleep(2)
         group_id = rospy.get_param("~arm_group_name")
         self.eef_step = rospy.get_param("~eef_step", 0.01)
-        self.jump_threshold = rospy.get_param("~jump_threshold", 1000)
 
         self.group = MoveGroupCommander(group_id)
         self._robot_name = self.robot._r.get_robot_name()
@@ -151,8 +150,7 @@ class WarehousePlanner:
             # +1 because current position is used as first waypiont.
             rospy.logerr("Not all waypoints existed, not executing.")
             return False
-        (plan, fraction) = self.group.compute_cartesian_path(
-            waypoints, self.eef_step, self.jump_threshold)
+        (plan, fraction) = self.group.compute_cartesian_path(waypoints, self.eef_step)
 
         if fraction < self._min_wp_fraction:
             rospy.logerr("Only managed to generate trajectory through" +

--- a/sr_robot_commander/src/sr_robot_commander/follow_warehouse_trajectory.py
+++ b/sr_robot_commander/src/sr_robot_commander/follow_warehouse_trajectory.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
-# Copyright © 2019, 2022-2023 belongs to Shadow Robot Company Ltd.
+# Copyright © 2019, 2022-2024 belongs to Shadow Robot Company Ltd.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -808,15 +808,13 @@ class SrRobotCommander:
                 rospy.loginfo("Trajectory not completed")
 
     def plan_to_waypoints_target(self, waypoints, reference_frame=None,
-                                 eef_step=0.005, jump_threshold=0.0, custom_start_state=None):
+                                 eef_step=0.005, custom_start_state=None):
         """
         Specify a set of waypoints for the end-effector and plans.
         This is a blocking method.
         @param reference_frame - the reference frame in which the waypoints are given.
         @param waypoints - an array of poses of end-effector.
         @param eef_step - configurations are computed for every eef_step meters.
-        @param jump_threshold - maximum distance in configuration space between consecutive points in the
-        resulting path.
         @param custom_start_state - specify a start state different than the current state.
         @return - motion plan (RobotTrajectory msg) that contains the trajectory to the set wayapoints targets.
         """
@@ -827,7 +825,7 @@ class SrRobotCommander:
         old_frame = self._move_group_commander.get_pose_reference_frame()
         if reference_frame is not None:
             self.set_pose_reference_frame(reference_frame)
-        self.__plan, fraction = self._move_group_commander.compute_cartesian_path(waypoints, eef_step, jump_threshold)
+        self.__plan, fraction = self._move_group_commander.compute_cartesian_path(waypoints, eef_step)
         self.set_pose_reference_frame(old_frame)
         return self.__plan, fraction
 

--- a/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
+++ b/sr_robot_commander/src/sr_robot_commander/sr_robot_commander.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 # Software License Agreement (BSD License)
-# Copyright © 2015, 2022-2023 belongs to Shadow Robot Company Ltd.
+# Copyright © 2015, 2022-2024 belongs to Shadow Robot Company Ltd.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,

--- a/sr_robot_launch/config/left_bimanual_ur10e_arm_robot_hw.yaml
+++ b/sr_robot_launch/config/left_bimanual_ur10e_arm_robot_hw.yaml
@@ -1,5 +1,5 @@
 # Software License Agreement (BSD License)
-# Copyright © 2022-2023 belongs to Shadow Robot Company Ltd.
+# Copyright © 2022-2024 belongs to Shadow Robot Company Ltd.
 # All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without modification,
@@ -53,7 +53,7 @@ la_sr_ur_robot_hw:
   
   servoj_gain: 250
   
-  servoj_lookahead_time: 0.07
+  servoj_lookahead_time: 0.1
   
   reverse_port: 51001
 

--- a/sr_robot_launch/launch/sr_ur_arm_hand.launch
+++ b/sr_robot_launch/launch/sr_ur_arm_hand.launch
@@ -1,6 +1,6 @@
 <!--
  Software License Agreement (BSD License)
- Copyright © 2022-2023 belongs to Shadow Robot Company Ltd.
+ Copyright © 2022-2024 belongs to Shadow Robot Company Ltd.
  All rights reserved.
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/sr_robot_launch/launch/sr_ur_arm_hand.launch
+++ b/sr_robot_launch/launch/sr_ur_arm_hand.launch
@@ -198,5 +198,5 @@
   </group>
 
   <!-- Publish underactuation error -->
-  <node name="error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
+  <node name="underactuation_error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
 </launch>

--- a/sr_robot_launch/launch/sr_ur_arms_hands.launch
+++ b/sr_robot_launch/launch/sr_ur_arms_hands.launch
@@ -1,6 +1,6 @@
 <!--
  Software License Agreement (BSD License)
- Copyright © 2022-2023 belongs to Shadow Robot Company Ltd.
+ Copyright © 2022-2024 belongs to Shadow Robot Company Ltd.
  All rights reserved.
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/sr_robot_launch/launch/sr_ur_arms_hands.launch
+++ b/sr_robot_launch/launch/sr_ur_arms_hands.launch
@@ -217,6 +217,6 @@
   </group>
 
   <!-- Publish underactuation error -->
-  <node name="error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
+  <node name="underactuation_error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
 
 </launch>

--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -66,8 +66,8 @@
   <arg if="$(eval arg('hand_id') == 'lh')" name="side" default="left"/>
   <!-- Set to hand_e or hand_g -->
   <arg name="hand_type" default="hand_e"/>
-  <arg if="$(eval arg('hand_type') == 'hand_e')" name="hand_version" default="E3M5"/>
-  <arg if="$(eval arg('hand_type') == 'hand_g')" name="hand_version" default="G1M5"/>
+  <arg if="$(eval arg('hand_type') == 'hand_e')" name="hand_version" default="E4"/>
+  <arg if="$(eval arg('hand_type') == 'hand_g')" name="hand_version" default="G4"/>
   <arg if="$(eval arg('hand_type') == 'hand_c')" name="hand_version" default="C6M2"/>
     <!-- Set to all allowed fingers by default but you can specify less using a list like this "th,ff,mf,rf,lf" -->
   <arg name="fingers" default="all"/>

--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -1,6 +1,6 @@
 <!--
  Software License Agreement (BSD License)
- Copyright © 2022-2023 belongs to Shadow Robot Company Ltd.
+ Copyright © 2022-2024 belongs to Shadow Robot Company Ltd.
  All rights reserved.
  Redistribution and use in source and binary forms, with or without modification,
  are permitted provided that the following conditions are met:

--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -135,5 +135,5 @@
   </include>  
 
   <!-- Publish underactuation error -->
-  <node name="error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
+  <node name="underactuation_error_reporter" pkg="sr_error_reporter" type="error_reporter" output="screen"/>
 </launch>

--- a/sr_robot_launch/launch/srhand.launch
+++ b/sr_robot_launch/launch/srhand.launch
@@ -72,7 +72,7 @@
     <!-- Set to all allowed fingers by default but you can specify less using a list like this "th,ff,mf,rf,lf" -->
   <arg name="fingers" default="all"/>
   <!-- Set to pst sensors by default but they can be specified by finger using a list like this "th=pst,ff=pst,mf=pst,rf=pst,lf=pst" -->
-  <arg name="tip_sensors" default="pst"/>
+  <arg name="tip_sensors" default="mst"/>
   <arg name="mid_sensors" default="none"/>
   <arg name="prox_sensors" default="none"/>
   <arg name="palm_sensor" default="none"/>


### PR DESCRIPTION
## Proposed changes

Make new hand versions (with new palm flesh) the default versions for Hands E and G (lite), respectively, versions E4 and G4. 
Also, renaming node `error_reporter` node to `underactuation_error_reporter` for clarity purposes and ensuring parameters `robot_description` and `robot_description_semantics` are discoverable before starting the node.

Update: This PR also now introduces fixes to some of our ROS tests (specifically, those invoking the method move_group.compute_cartesian_path() ), so that they now conform with the latest API changes to moveit_commander:
[https://github.com/moveit/moveit/pull/3618](https://github.com/moveit/moveit/pull/3618)
Specifically, the argument `jump_threshold` has now been deprecated, and, therefore, had to be removed

## Checklist

Before posting a PR ensure that from each of the below categories **AT LEAST ONE BOX HAS BEEN CHECKED**. If more than one category is applicable then more can be checked. Also ensure that the proposed changes have been filled out with relevant information for reviewers.

## Tests

- [ ] No tests required to be added. (For small changes that will be tested by CI/CD infrastructure).
- [ ] Added/Modified automated and PhantomHand CI tests (if a new class is added (Python or C++), the interface of that class must be unit tested).
- [x] Manually tested in simulation (if simulation specific or no hardware required to test the functionality). 
- [ ] Manually tested on hardware (if hardware specific or related).

## Documentation

- [x] No documentation required to be added.
- [ ] Added documentation (For any new feature, explain what it does and how to use it. Write the documentation in a relevant space, e.g. Github, Confluence, etc).
- [ ] Updated documentation (For changes to pre-existing features mentioned in the documentation).
